### PR TITLE
Fix release workflow asset upload race condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,12 +177,14 @@ jobs:
           fi
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: all-releases/*
           draft: false
           prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}
           generate_release_notes: true
+          fail_on_unmatched_files: true
+          make_latest: true
           body: |
             ## Release ${{ steps.version.outputs.VERSION }}
             


### PR DESCRIPTION
## Problem

The release workflow is failing with:
```
Failed to upload release asset. received status code 422
Cannot upload assets to an immutable release.
```

## Root Cause

`softprops/action-gh-release@v1` has a race condition when uploading multiple assets in parallel. One asset upload publishes the release, making it immutable before other uploads complete.

## Solution

- Upgraded to `softprops/action-gh-release@v2` which handles concurrent uploads properly
- Added `fail_on_unmatched_files: true` to catch upload errors early
- Added `make_latest: true` to explicitly mark as latest release

## Testing

After merge, will recreate v1.1.1 tag to verify all assets upload successfully.

Fixes the issue blocking v1.1.1 release.