### PR TITLE
fix: parsing XML in PullMessages

### DIFF
--- a/event.go
+++ b/event.go
@@ -307,17 +307,21 @@ func (c *Client) PullMessages(
 				Address string `xml:"Address"`
 			} `xml:"ProducerReference"`
 			Message struct {
-				PropertyOperation string `xml:"PropertyOperation,attr"`
-				UtcTime           string `xml:"UtcTime,attr"`
-				Source            struct {
-					SimpleItems []SimpleItemXML `xml:"SimpleItem"`
-				} `xml:"Source"`
-				Key struct {
-					SimpleItems []SimpleItemXML `xml:"SimpleItem"`
-				} `xml:"Key"`
-				Data struct {
-					SimpleItems []SimpleItemXML `xml:"SimpleItem"`
-				} `xml:"Data"`
+				XMLName xml.Name `xml:"Message"`
+				Inner   struct {
+					XMLName           xml.Name `xml:"Message"`
+					PropertyOperation string   `xml:"PropertyOperation,attr"`
+					UtcTime           string   `xml:"UtcTime,attr"`
+					Source            struct {
+						SimpleItems []SimpleItemXML `xml:"SimpleItem"`
+					} `xml:"Source"`
+					Key struct {
+						SimpleItems []SimpleItemXML `xml:"SimpleItem"`
+					} `xml:"Key"`
+					Data struct {
+						SimpleItems []SimpleItemXML `xml:"SimpleItem"`
+					} `xml:"Data"`
+				} `xml:"Message"`
 			} `xml:"Message"`
 		} `xml:"NotificationMessage"`
 	}
@@ -345,29 +349,29 @@ func (c *Client) PullMessages(
 			ProducerAddress: nm.ProducerReference.Address,
 		}
 
-		msg.Message.PropertyOperation = nm.Message.PropertyOperation
+		msg.Message.PropertyOperation = nm.Message.Inner.PropertyOperation
 
-		if nm.Message.UtcTime != "" {
-			if t, err := time.Parse(time.RFC3339, nm.Message.UtcTime); err == nil {
+		if nm.Message.Inner.UtcTime != "" {
+			if t, err := time.Parse(time.RFC3339, nm.Message.Inner.UtcTime); err == nil {
 				msg.Message.UtcTime = t
 			}
 		}
 
 		// Convert source items.
-		msg.Message.Source = make([]SimpleItem, len(nm.Message.Source.SimpleItems))
-		for j, item := range nm.Message.Source.SimpleItems {
+		msg.Message.Source = make([]SimpleItem, len(nm.Message.Inner.Source.SimpleItems))
+		for j, item := range nm.Message.Inner.Source.SimpleItems {
 			msg.Message.Source[j] = SimpleItem(item)
 		}
 
 		// Convert key items.
-		msg.Message.Key = make([]SimpleItem, len(nm.Message.Key.SimpleItems))
-		for j, item := range nm.Message.Key.SimpleItems {
+		msg.Message.Key = make([]SimpleItem, len(nm.Message.Inner.Key.SimpleItems))
+		for j, item := range nm.Message.Inner.Key.SimpleItems {
 			msg.Message.Key[j] = SimpleItem(item)
 		}
 
 		// Convert data items.
-		msg.Message.Data = make([]SimpleItem, len(nm.Message.Data.SimpleItems))
-		for j, item := range nm.Message.Data.SimpleItems {
+		msg.Message.Data = make([]SimpleItem, len(nm.Message.Inner.Data.SimpleItems))
+		for j, item := range nm.Message.Inner.Data.SimpleItems {
 			msg.Message.Data[j] = SimpleItem(item)
 		}
 

--- a/event.go
+++ b/event.go
@@ -307,11 +307,12 @@ func (c *Client) PullMessages(
 				Address string `xml:"Address"`
 			} `xml:"ProducerReference"`
 			Message struct {
-				XMLName xml.Name `xml:"Message"`
-				Inner   struct {
-					XMLName           xml.Name `xml:"Message"`
-					PropertyOperation string   `xml:"PropertyOperation,attr"`
-					UtcTime           string   `xml:"UtcTime,attr"`
+				// wsnt:Message is a wrapper (b-2.xsd declares it as xsd:any with
+				// no attributes); the ONVIF tt:Message inside it carries the
+				// attributes and the item lists.
+				Inner struct {
+					PropertyOperation string `xml:"PropertyOperation,attr"`
+					UtcTime           string `xml:"UtcTime,attr"`
 					Source            struct {
 						SimpleItems []SimpleItemXML `xml:"SimpleItem"`
 					} `xml:"Source"`

--- a/event_test.go
+++ b/event_test.go
@@ -67,16 +67,18 @@ func newMockEventServer() *httptest.Server {
         <wsnt:ProducerReference>
           <wsa:Address xmlns:wsa="http://www.w3.org/2005/08/addressing">http://192.168.1.100</wsa:Address>
         </wsnt:ProducerReference>
-        <wsnt:Message PropertyOperation="Changed" UtcTime="2025-01-15T10:29:55Z">
-          <tt:Source xmlns:tt="http://www.onvif.org/ver10/schema">
-            <tt:SimpleItem Name="VideoSourceToken" Value="video_src_001"/>
-          </tt:Source>
-          <tt:Key xmlns:tt="http://www.onvif.org/ver10/schema">
-            <tt:SimpleItem Name="RuleToken" Value="rule_001"/>
-          </tt:Key>
-          <tt:Data xmlns:tt="http://www.onvif.org/ver10/schema">
-            <tt:SimpleItem Name="State" Value="true"/>
-          </tt:Data>
+        <wsnt:Message>
+          <tt:Message xmlns:tt="http://www.onvif.org/ver10/schema" PropertyOperation="Changed" UtcTime="2025-01-15T10:29:55Z">
+            <tt:Source>
+              <tt:SimpleItem Name="VideoSourceToken" Value="video_src_001"/>
+            </tt:Source>
+            <tt:Key>
+              <tt:SimpleItem Name="RuleToken" Value="rule_001"/>
+            </tt:Key>
+            <tt:Data>
+              <tt:SimpleItem Name="State" Value="true"/>
+            </tt:Data>
+          </tt:Message>
         </wsnt:Message>
       </wsnt:NotificationMessage>
     </tev:PullMessagesResponse>


### PR DESCRIPTION
When receiving events, almost all fields were empty due to the fact that the Message structure had no nesting. It's fixed now.