### PR TITLE
fix: add XML tags to StorageConfiguration types

### DIFF
--- a/device_storage_test.go
+++ b/device_storage_test.go
@@ -2,6 +2,7 @@ package onvif
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -25,20 +26,16 @@ func newMockDeviceStorageServer() *httptest.Server {
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
   <SOAP-ENV:Body>
     <tds:GetStorageConfigurationsResponse>
-      <tds:StorageConfigurations>
-        <tt:Token>storage-001</tt:Token>
-        <tt:Data>
+      <tds:StorageConfigurations token="storage-001">
+        <tt:Data type="NFS">
           <tt:LocalPath>/var/media/storage1</tt:LocalPath>
           <tt:StorageUri>file:///var/media/storage1</tt:StorageUri>
-          <tt:Type>NFS</tt:Type>
         </tt:Data>
       </tds:StorageConfigurations>
-      <tds:StorageConfigurations>
-        <tt:Token>storage-002</tt:Token>
-        <tt:Data>
+      <tds:StorageConfigurations token="storage-002">
+        <tt:Data type="CIFS">
           <tt:LocalPath>/var/media/storage2</tt:LocalPath>
           <tt:StorageUri>cifs://nas.local/recordings</tt:StorageUri>
-          <tt:Type>CIFS</tt:Type>
         </tt:Data>
       </tds:StorageConfigurations>
     </tds:GetStorageConfigurationsResponse>
@@ -50,12 +47,10 @@ func newMockDeviceStorageServer() *httptest.Server {
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
   <SOAP-ENV:Body>
     <tds:GetStorageConfigurationResponse>
-      <tds:StorageConfiguration>
-        <tt:Token>storage-001</tt:Token>
-        <tt:Data>
+      <tds:StorageConfiguration token="storage-001">
+        <tt:Data type="NFS">
           <tt:LocalPath>/var/media/storage1</tt:LocalPath>
           <tt:StorageUri>file:///var/media/storage1</tt:StorageUri>
-          <tt:Type>NFS</tt:Type>
         </tt:Data>
       </tds:StorageConfiguration>
     </tds:GetStorageConfigurationResponse>
@@ -235,6 +230,67 @@ func TestSetStorageConfiguration(t *testing.T) {
 	err = client.SetStorageConfiguration(ctx, config)
 	if err != nil {
 		t.Fatalf("SetStorageConfiguration failed: %v", err)
+	}
+}
+
+// TestSetStorageConfigurationWireFormat asserts the outbound payload matches the
+// ONVIF schema: token and type are attributes, and the URI element is StorageUri.
+func TestSetStorageConfigurationWireFormat(t *testing.T) {
+	var requestBody string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading request body: %v", err)
+		}
+		requestBody = string(body)
+
+		w.Header().Set("Content-Type", "application/soap+xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
+  <SOAP-ENV:Body>
+    <tds:SetStorageConfigurationResponse/>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+
+	config := &StorageConfiguration{
+		Token: "storage-001",
+		Data: StorageConfigurationData{
+			LocalPath:  "/var/media/updated",
+			StorageURI: "file:///var/media/updated",
+			Type:       "NFS",
+		},
+	}
+
+	if err := client.SetStorageConfiguration(context.Background(), config); err != nil {
+		t.Fatalf("SetStorageConfiguration failed: %v", err)
+	}
+
+	for _, want := range []string{
+		`token="storage-001"`,
+		`type="NFS"`,
+		"<StorageUri>file:///var/media/updated</StorageUri>",
+	} {
+		if !strings.Contains(requestBody, want) {
+			t.Errorf("request body missing %s\nbody:\n%s", want, requestBody)
+		}
+	}
+
+	for _, unwanted := range []string{
+		"<Token>",
+		"<Type>",
+		"<StorageURI>",
+	} {
+		if strings.Contains(requestBody, unwanted) {
+			t.Errorf("request body contains non-spec element %s\nbody:\n%s", unwanted, requestBody)
+		}
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -1178,18 +1178,21 @@ const (
 )
 
 // StorageConfiguration represents storage configuration.
+// Extends tt:DeviceEntity, whose token is an XML attribute.
 type StorageConfiguration struct {
-	Token string
-	Data  StorageConfigurationData
+	Token string                   `xml:"token,attr"`
+	Data  StorageConfigurationData `xml:"Data"`
 }
 
 // StorageConfigurationData represents storage configuration data.
+// Tags are required: the wire names differ from the Go field names
+// (type is an attribute, and the spec spells the URI element StorageUri).
 type StorageConfigurationData struct {
-	Type                       string
-	LocalPath                  string
-	StorageURI                 string
-	User                       *UserCredential
-	CertPathValidationPolicyID string
+	Type                       string          `xml:"type,attr"`
+	LocalPath                  string          `xml:"LocalPath,omitempty"`
+	StorageURI                 string          `xml:"StorageUri,omitempty"`
+	User                       *UserCredential `xml:"User,omitempty"`
+	CertPathValidationPolicyID string          `xml:"CertPathValidationPolicyID,omitempty"`
 }
 
 // UserCredential represents user credentials.


### PR DESCRIPTION
Fixes #56.

`GetStorageConfiguration(s)` returned near-empty structs against any conformant camera — only `LocalPath` was populated, with `Token`, `Type` and `StorageURI` all empty.

## Cause

`types.go:1181-1193` declared both storage types with no xml struct tags, and `device_storage.go` unmarshals responses **directly** into them. With no tags, `encoding/xml` matches by Go field name, case-sensitively — so the Go field name was the wire contract. `96ac509` renamed `StorageUri` → `StorageURI` for Go initialism style and correctly left the fixture element alone; nothing pinned the wire name, so the match silently broke.

Two further mismatches were masked by the fixture being wrong in the same direction as the struct: per the WSDL, `type` is an `xs:attribute` and `token` is an attribute inherited from `tt:DeviceEntity`, but both were matched as child elements while the fixture emitted non-spec `<tt:Type>`/`<tt:Token>` elements. The assertions passed; real cameras returned nothing.

## Change

Tags added to both types, using bare local names rather than `tds:`-qualified ones so matching stays namespace-agnostic across cameras that vary their prefixes:

```go
type StorageConfiguration struct {
	Token string                   `xml:"token,attr"`
	Data  StorageConfigurationData `xml:"Data"`
}

type StorageConfigurationData struct {
	Type                       string          `xml:"type,attr"`
	LocalPath                  string          `xml:"LocalPath,omitempty"`
	StorageURI                 string          `xml:"StorageUri,omitempty"`
	User                       *UserCredential `xml:"User,omitempty"`
	CertPathValidationPolicyID string          `xml:"CertPathValidationPolicyID,omitempty"`
}
```

The mock fixture is corrected to spec shape in the same commit — necessarily, since adding `token,attr`/`type,attr` makes the previously *passing* `Token`/`Type` assertions fail against a non-spec fixture.

The same tags also fix outbound marshaling, which had the mirror-image bug: `Create`/`SetStorageConfiguration` emitted `Token` and `Type` as child elements and the URI as `<StorageURI>`. Nothing covered the request payload, so this adds `TestSetStorageConfigurationWireFormat`.

## Verification

Written test-first. With the fixture made spec-shaped and the tags absent, the failure is exactly the real-camera behaviour:

```
device_storage_test.go:129: Expected first config token 'storage-001', got ''
device_storage_test.go:137: Expected first config type 'NFS', got ''
device_storage_test.go:141: Expected second config token 'storage-002', got ''
device_storage_test.go:145: Expected second config URI 'cifs://nas.local/recordings', got ''
```

The new wire-format test was likewise confirmed to fail with the tags stashed:

```
request body missing token="storage-001"
request body contains non-spec element <Token>
```

Both green after the change. Under Go 1.26.6: `gofmt` clean, `go vet ./...` clean, `go test -race ./...` — the root package now passes in full.

The two remaining failures in `server/soap` are #55 and are untouched here; they fail identically on `master`. `golangci-lint` is not installed locally, so lint is left to CI.

## Not addressed

#57 — `CreateStorageConfiguration` sends `StorageConfiguration` where the WSDL requires `StorageConfigurationData`. That is a breaking signature change and wants its own PR.