### PR TITLE
ci: correct two action pins to real commit SHAs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         continue-on-error: true
       
       - name: Validate markdown
-        uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2c8a4c84aa7067b5e06 # v19.0.0
+        uses: DavidAnson/markdownlint-cli2-action@a23dae216ce3fee4db69da41fed90d2a4af801cf # v19.0.0
         with:
           globs: 'docs/**/*.md'
         continue-on-error: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,7 +27,7 @@ jobs:
           go-version: '1.26.x'
       
       - name: Run gosec
-        uses: securego/gosec@549db668017d67c5eedc9ee8a695208bc3af7c23 # v2.29.0
+        uses: securego/gosec@deb54465fea23d19a77f037e11e6589021f8501d # v2.29.0
         with:
           args: -no-fail -fmt json -out gosec-report.json ./...
       


### PR DESCRIPTION
Fixes the `Validate markdown` step, which currently cannot start at all:

```
Error: Unable to resolve action `davidanson/markdownlint-cli2-action@05f32210e84442804257b2c8a4c84aa7067b5e06`,
unable to find version `05f32210e84442804257b2c8a4c84aa7067b5e06`
```

## markdownlint-cli2-action (pre-existing break)

`docs.yml:30` pinned `05f32210e84442804257b2c8a4c84aa7067b5e06`, which exists nowhere in that repository — the commits API returns `422 No commit found for SHA`. The trailing comment claims v19.0.0, whose actual commit is `a23dae216ce3fee4db69da41fed90d2a4af801cf`. Repointed there, keeping the stated version.

Introduced in `00e2e0d`. Unrelated to any recent dependency work.

Worth noting the action is now at **v24.2.0**, so v19.0.0 is well behind; this PR deliberately only restores the pin to what the comment always claimed rather than bundling an upgrade. Say the word if you'd rather jump to v24.

## gosec (tidying my own pin from #54)

`security.yml` pinned `549db668`, which is the *annotated tag object* for v2.29.0, not a commit. GitHub Actions does resolve it — the scan ran and pulled the image on #54, so nothing was broken — but every other pin in these workflows is a commit SHA, and a tag object is not resolvable through the commits API, which makes automated pin auditing report a false missing. Repointed to `deb54465`, the commit v2.29.0 tags.

## Audit

I checked all 18 pinned actions across every workflow, not just the one that errored. These two were the only pins that did not resolve to a commit; the other 16 are untouched:

```
OK  actions/cache, actions/checkout, actions/dependency-review-action,
    actions/download-artifact, actions/setup-go, actions/upload-artifact,
    codecov/codecov-action, docker/build-push-action, docker/login-action,
    docker/setup-buildx-action, docker/setup-qemu-action,
    golangci/golangci-lint-action, golang/govulncheck-action,
    lycheeverse/lychee-action, softprops/action-gh-release,
    SonarSource/sonarcloud-github-action
```

After this change all 18 resolve as commits.