### PR TITLE
fix: CreateStorageConfiguration takes StorageConfigurationData

### DIFF
--- a/device_storage.go
+++ b/device_storage.go
@@ -64,13 +64,14 @@ func (c *Client) GetStorageConfiguration(ctx context.Context, token string) (*St
 	return response.StorageConfiguration, nil
 }
 
-// CreateStorageConfiguration creates a storage configuration.
+// CreateStorageConfiguration creates a storage configuration. The device assigns
+// the token and returns it; the request must not carry one.
 // ONVIF Specification: CreateStorageConfiguration operation.
-func (c *Client) CreateStorageConfiguration(ctx context.Context, config *StorageConfiguration) (string, error) {
+func (c *Client) CreateStorageConfiguration(ctx context.Context, data *StorageConfigurationData) (string, error) {
 	type CreateStorageConfigurationBody struct {
-		XMLName              xml.Name              `xml:"tds:CreateStorageConfiguration"`
-		Xmlns                string                `xml:"xmlns:tds,attr"`
-		StorageConfiguration *StorageConfiguration `xml:"tds:StorageConfiguration"`
+		XMLName xml.Name                  `xml:"tds:CreateStorageConfiguration"`
+		Xmlns   string                    `xml:"xmlns:tds,attr"`
+		Data    *StorageConfigurationData `xml:"tds:StorageConfiguration"`
 	}
 
 	type CreateStorageConfigurationResponse struct {
@@ -79,8 +80,8 @@ func (c *Client) CreateStorageConfiguration(ctx context.Context, config *Storage
 	}
 
 	request := CreateStorageConfigurationBody{
-		Xmlns:                deviceNamespace,
-		StorageConfiguration: config,
+		Xmlns: deviceNamespace,
+		Data:  data,
 	}
 	var response CreateStorageConfigurationResponse
 

--- a/device_storage_test.go
+++ b/device_storage_test.go
@@ -189,22 +189,75 @@ func TestCreateStorageConfiguration(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	config := &StorageConfiguration{
-		Token: "storage-new",
-		Data: StorageConfigurationData{
-			LocalPath:  "/var/media/storage3",
-			StorageURI: "file:///var/media/storage3",
-			Type:       "Local",
-		},
+	data := &StorageConfigurationData{
+		LocalPath:  "/var/media/storage3",
+		StorageURI: "file:///var/media/storage3",
+		Type:       "Local",
 	}
 
-	token, err := client.CreateStorageConfiguration(ctx, config)
+	token, err := client.CreateStorageConfiguration(ctx, data)
 	if err != nil {
 		t.Fatalf("CreateStorageConfiguration failed: %v", err)
 	}
 
 	if token != "storage-new" {
 		t.Errorf("Expected token 'storage-new', got '%s'", token)
+	}
+}
+
+// TestCreateStorageConfigurationWireFormat asserts the outbound payload matches the
+// ONVIF schema: the device assigns the token, so the request must carry only
+// StorageConfigurationData, never a token attribute.
+func TestCreateStorageConfigurationWireFormat(t *testing.T) {
+	var requestBody string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading request body: %v", err)
+		}
+		requestBody = string(body)
+
+		w.Header().Set("Content-Type", "application/soap+xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
+  <SOAP-ENV:Body>
+    <tds:CreateStorageConfigurationResponse>
+      <tds:Token>storage-new</tds:Token>
+    </tds:CreateStorageConfigurationResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+
+	data := &StorageConfigurationData{
+		LocalPath:  "/var/media/storage3",
+		StorageURI: "file:///var/media/storage3",
+		Type:       "Local",
+	}
+
+	if _, err := client.CreateStorageConfiguration(context.Background(), data); err != nil {
+		t.Fatalf("CreateStorageConfiguration failed: %v", err)
+	}
+
+	for _, want := range []string{
+		`type="Local"`,
+		`<StorageUri>file:///var/media/storage3</StorageUri>`,
+	} {
+		if !strings.Contains(requestBody, want) {
+			t.Errorf("request body missing %q, got: %s", want, requestBody)
+		}
+	}
+
+	for _, unwanted := range []string{`token=`, `<Token>`} {
+		if strings.Contains(requestBody, unwanted) {
+			t.Errorf("request body should not contain %q (device assigns the token), got: %s", unwanted, requestBody)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- `CreateStorageConfiguration` now takes `*StorageConfigurationData` instead of `*StorageConfiguration`, matching the WSDL's `tds:StorageConfigurationData` request body.
- The device assigns the token on create; the caller was previously able to send one anyway, which the spec doesn't permit for this operation.
- Breaking change to the exported signature, as flagged in #57.

## Test plan
- [x] Updated `TestCreateStorageConfiguration` to call the new signature
- [x] Added `TestCreateStorageConfigurationWireFormat` asserting the outbound payload has no `token=` attribute or `<Token>` element
- [x] Full suite, `go vet`, `gofmt` clean

Fixes #57