### PR TITLE
fix: work around codecov-action's dead Keybase GPG key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,10 @@ jobs:
           # Don't fail on PRs from forks where token may not be available
           fail_ci_if_error: ${{ github.event_name == 'push' }}
           verbose: true
+          # codecov-action's default uploader verifies its own binary against a
+          # GPG key hosted on keybase.io, which now 404s (codecov/codecov-action#1955).
+          # use_pypi installs the uploader from PyPI instead, bypassing that dead path.
+          use_pypi: true
 
   # Stage 4: SonarCloud Analysis (depends on test)
   # Only runs on push to master/main when SONAR_TOKEN is available


### PR DESCRIPTION
## Summary

\`Test & Coverage\` has failed on every push to master since #68 merged. It's not our tests — the actual \`go test\` step passes fine, and its own failures are swallowed by \`|| true\` upstream anyway. \`fail_ci_if_error\` on the Codecov upload step is what's failing the job, and the upload step itself is failing because codecov-action's uploader tries to verify itself against a GPG key hosted at \`keybase.io/codecovsecurity/pgp_keys.asc\`, which now 404s:

```
gpg: no valid OpenPGP data found.
...
Can't check signature: No public key
Exiting...
```

This is an upstream, currently-open issue: codecov/codecov-action#1955 (closed as a similar prior report, but the underlying Keybase 404 is back). The documented workaround is \`use_pypi: true\`, which installs the codecov-cli from PyPI instead of going through the broken Keybase-verified path.

## Test plan
- [x] Confirmed \`go test ./...\` passes on the affected commit locally
- [x] Confirmed via job logs that only the \`Upload to Codecov\` step fails, with the exact GPG error from codecov-action#1955
- [ ] Watch this PR's own CI run to confirm the upload step now succeeds (PRs don't set \`fail_ci_if_error\`, so this won't gate the PR either way — will check logs directly)