### PR TITLE
fix: scope GitHub Actions permissions to job level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,6 @@ on:
     branches: [master, main]
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: read
-  checks: write
-  pull-requests: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -24,6 +19,8 @@ jobs:
   fmt:
     name: Format Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -50,6 +47,12 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     needs: fmt
+    permissions:
+      contents: read
+      # only-new-issues needs to read the PR diff.
+      pull-requests: read
+      # Lets golangci-lint-action annotate the offending lines in the PR.
+      checks: write
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -93,6 +96,8 @@ jobs:
     name: Test & Coverage
     runs-on: ubuntu-latest
     needs: lint
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -158,6 +163,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && github.repository == '0x524a/onvif-go'
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -192,6 +199,8 @@ jobs:
     name: Build Verification
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -232,6 +241,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [fmt, lint, test, sonarcloud, build]
     if: always()
+    # Only reads the `needs` context; doesn't check out code or call any API.
+    permissions: {}
     steps:
       - name: Check all jobs status
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,13 @@ on:
         description: 'Release version (e.g., v1.2.3)'
         required: true
 
-permissions:
-  contents: write
-
 jobs:
   build:
     name: Build Release Binaries
     runs-on: ubuntu-latest
+    # Only builds and uploads a workflow artifact; doesn't touch releases or packages.
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -153,6 +153,8 @@ jobs:
     name: Create GitHub Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -244,6 +246,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch'
+    # packages: write is required to push to ghcr.io with GITHUB_TOKEN. The
+    # workflow-level block this replaced only granted contents: write, which
+    # left packages at the implicit "none" default — every push here would
+    # have been rejected regardless of Docker Hub/GHCR auth.
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,15 +8,14 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday
 
-permissions:
-  contents: read
-  security-events: write
-
 jobs:
   gosec:
     name: Security Scan (gosec)
     runs-on: ubuntu-latest
-    
+    # No SARIF upload step, so no security-events permission is needed here.
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -53,7 +52,9 @@ jobs:
   govulncheck:
     name: Vulnerability Check (govulncheck)
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary

Resolves the S8233/S8264 items from #59's Sonar debt inventory: workflow-level `permissions:` blocks should be declared per-job instead, so each job only gets what it actually calls.

- **ci.yml**: `lint` keeps `checks: write` (golangci-lint-action's PR annotations) and adds `pull-requests: read` (needed for `only-new-issues`, per the action's own docs — was over-scoped to `write` before, for no reason anything in this workflow uses). Every other job drops to `contents: read`. `ci-success` gets `permissions: {}` — it only reads the `needs` context, no checkout, no API calls.
- **security.yml**: dropped `security-events: write` entirely. Nothing in this workflow uploads a SARIF report; it was granted and unused.
- **release.yml**: `build` only needs `contents: read`. `release` (creates the GitHub Release, uploads assets) needs `contents: write`. `docker` needs `packages: write` to push to ghcr.io.

## A real bug found along the way

While auditing `release.yml` I checked this repo's actual release run history — **every release run has failed**, `Create GitHub Release` and `Build and Push Docker Image` both, going back to v1.0.1. Logs are past GitHub's retention window so I can't get an exact trace, but one concrete cause is visible from the workflow itself: the old top-level block granted only `contents: write`. Because an explicit `permissions:` block overrides GitHub's default token scopes entirely (not just narrows them), `packages` was implicitly `none` — the GHCR push in the `docker` job could never have authenticated, independent of anything with Docker Hub/GHCR credentials. Fixed here by adding `packages: write` to that job.

`Create GitHub Release`'s failure is still unexplained. I'm not guessing at a fix for it blind — it only runs on a real tag push or `workflow_dispatch`, both of which create a real GitHub Release and push a real Docker image, so it needs a deliberate test run, not something to iterate on speculatively.

## Test plan
- [x] YAML validated (`python3 -c 'import yaml; yaml.safe_load(...)'`) on all three files
- [ ] Confirm CI itself still passes end-to-end on this PR (checkout/lint/test/build steps all still work with narrowed permissions)
- [ ] `packages: write` fix can only be confirmed on an actual tag push — flagging for manual follow-up, not claiming it's proven here

Part of #59