### PR TITLE
fix: switch to sonarqube-scan-action for Java 21 scanner support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,13 @@ jobs:
           fi
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@4006f663ecaf1f8093e8e4abb9227f6041f52216 # v3.1.0
+        # sonarcloud-github-action is deprecated in favor of this action, which
+        # is what both SonarCloud and self-hosted SonarQube now use. Needed the
+        # switch anyway: v3.1.0's bundled scanner CLI requires Java 17, which
+        # SonarCloud's server no longer accepts ("Java 17 is not supported.
+        # Please upgrade to Java 21 or newer"). This one defaults to a scanner
+        # built against a current JRE.
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

Master's `SonarCloud Analysis` job started failing right after Automatic Analysis was disabled for this project (it had been silently masking this the whole time — see #59 discussion). The actual failure:

```
java.lang.IllegalStateException: Java 17 is not supported. Please upgrade
to Java 21 or newer, or use JRE auto-provisioning...
```

`SonarSource/sonarcloud-github-action@v3.1.0`'s bundled scanner CLI is built against Java 17, and SonarCloud's server no longer accepts that. That action is deprecated upstream in favor of `SonarSource/sonarqube-scan-action`, which is what SonarSource now maintains for both SonarCloud and self-hosted SonarQube. Same `projectBaseDir` input (unset, defaults to `.` in both), so this is a drop-in swap — just a newer, actively maintained action with a current default scanner version.

## Caveat on testing

The `sonarcloud` job only runs `if: github.event_name == 'push' && ... refs/heads/master`, so this PR's own CI can't exercise it — it'll only be provable by merging to master and checking the next run.

Part of #59