### PR TITLE
docs: remove dead Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # onvif-go - ONVIF Client and Server Library for Go
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/0x524a/onvif-go.svg)](https://pkg.go.dev/github.com/0x524a/onvif-go)
-[![Go Report Card](https://goreportcard.com/badge/github.com/0x524a/onvif-go)](https://goreportcard.com/report/github.com/0x524a/onvif-go)
 [![codecov](https://codecov.io/gh/0x524a/onvif-go/branch/master/graph/badge.svg)](https://codecov.io/gh/0x524a/onvif-go)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=0x524a_onvif-go&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=0x524a_onvif-go)
 [![License](https://img.shields.io/github/license/0x524a/onvif-go)](LICENSE)


### PR DESCRIPTION
goreportcard.com has been sunset (shut down entirely) after over a decade of service, per their own site: "Go Report Card has been sunset... It went on to grade millions of repositories and became a small, familiar badge on countless READMEs." The badge on our README now permanently renders "retired" — not a scan result, just a dead service. Removing it since there's no successor to point at.

Left the SonarCloud Quality Gate badge alone — checked it separately, and it's genuinely rendering "failed" right now, which matches known pre-existing debt (#59's remainder, hotspots, etc.) that's actively being worked, not a broken badge.