### PR TITLE
fix: resolve remaining goconst/nlreturn/prealloc lint debt

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -14,22 +14,22 @@ import (
 )
 
 const (
-	testEndpoint                          = "http://192.168.1.100/onvif"
-	testUsername                          = "admin"
-	testRealm                             = "test-realm"
-	testOpaque                            = "test-opaque"
-	testCameraIP                          = "192.168.1.100"
-	testCameraPort                        = "8080"
-	testCameraDeviceServicePath           = "/onvif/device_service"
-	testCameraMediaServicePath            = "/onvif/media_service"
-	testDeviceServiceURL                  = "http://192.168.1.100/onvif/device_service"
-	testDeviceServiceWithPortURL          = "http://192.168.1.100:8080/onvif/device_service"
-	testDeviceServiceHTTPSURL             = "https://192.168.1.100/onvif/device_service"
-	testMediaServiceURL                   = "http://192.168.1.100/onvif/media_service"
-	testPasswordLiteral                   = "password"
-	testPassword                          = "test123"
-	testHTTPScheme                        = "http"
-	testInvalidSchemeMarker               = "://invalid"
+	testEndpoint                 = "http://192.168.1.100/onvif"
+	testUsername                 = "admin"
+	testRealm                    = "test-realm"
+	testOpaque                   = "test-opaque"
+	testCameraIP                 = "192.168.1.100"
+	testCameraPort               = "8080"
+	testCameraDeviceServicePath  = "/onvif/device_service"
+	testCameraMediaServicePath   = "/onvif/media_service"
+	testDeviceServiceURL         = "http://192.168.1.100/onvif/device_service"
+	testDeviceServiceWithPortURL = "http://192.168.1.100:8080/onvif/device_service"
+	testDeviceServiceHTTPSURL    = "https://192.168.1.100/onvif/device_service"
+	testMediaServiceURL          = "http://192.168.1.100/onvif/media_service"
+	testPasswordLiteral          = "password"
+	testPassword                 = "test123"
+	testHTTPScheme               = "http"
+	testInvalidSchemeMarker      = "://invalid"
 )
 
 func TestNormalizeEndpoint(t *testing.T) {
@@ -544,7 +544,7 @@ func TestInitializeEndpointDiscovery(t *testing.T) {
 
 func TestGetProfilesRequiresInitialization(t *testing.T) {
 	client, err := NewClient(
-		"http://192.168.1.100/onvif/device_service",
+		testDeviceServiceURL,
 		WithCredentials(testUsername, "password"),
 	)
 	if err != nil {
@@ -647,7 +647,7 @@ func BenchmarkGetDeviceInformation(b *testing.B) {
 func ExampleClient_GetDeviceInformation() {
 	// Create client
 	client, err := NewClient(
-		"http://192.168.1.100/onvif/device_service",
+		testDeviceServiceURL,
 		WithCredentials(testUsername, "password"),
 		WithTimeout(30*time.Second),
 	)
@@ -675,9 +675,9 @@ func TestFixLocalhostURL(t *testing.T) {
 	}{
 		{
 			name:        "localhost hostname",
-			clientURL:   "http://192.168.1.100/onvif/device_service",
+			clientURL:   testDeviceServiceURL,
 			serviceURL:  "http://localhost/onvif/media_service",
-			expectedURL: "http://192.168.1.100/onvif/media_service",
+			expectedURL: testMediaServiceURL,
 		},
 		{
 			name:        "127.0.0.1 loopback",
@@ -687,31 +687,31 @@ func TestFixLocalhostURL(t *testing.T) {
 		},
 		{
 			name:        "0.0.0.0 address",
-			clientURL:   "http://192.168.1.100/onvif/device_service",
+			clientURL:   testDeviceServiceURL,
 			serviceURL:  "http://0.0.0.0/onvif/imaging_service",
 			expectedURL: "http://192.168.1.100/onvif/imaging_service",
 		},
 		{
 			name:        "IPv6 loopback",
-			clientURL:   "http://192.168.1.100/onvif/device_service",
+			clientURL:   testDeviceServiceURL,
 			serviceURL:  "http://[::1]/onvif/events_service",
 			expectedURL: "http://192.168.1.100/onvif/events_service",
 		},
 		{
 			name:        "localhost with different port",
-			clientURL:   "http://192.168.1.100/onvif/device_service",
+			clientURL:   testDeviceServiceURL,
 			serviceURL:  "http://localhost:8080/onvif/media_service",
 			expectedURL: "http://192.168.1.100:8080/onvif/media_service",
 		},
 		{
 			name:        "valid IP address unchanged",
-			clientURL:   "http://192.168.1.100/onvif/device_service",
-			serviceURL:  "http://192.168.1.100/onvif/media_service",
-			expectedURL: "http://192.168.1.100/onvif/media_service",
+			clientURL:   testDeviceServiceURL,
+			serviceURL:  testMediaServiceURL,
+			expectedURL: testMediaServiceURL,
 		},
 		{
 			name:        "different valid IP unchanged",
-			clientURL:   "http://192.168.1.100/onvif/device_service",
+			clientURL:   testDeviceServiceURL,
 			serviceURL:  "http://192.168.1.50/onvif/media_service",
 			expectedURL: "http://192.168.1.50/onvif/media_service",
 		},
@@ -729,7 +729,7 @@ func TestFixLocalhostURL(t *testing.T) {
 		},
 		{
 			name:        "empty service URL",
-			clientURL:   "http://192.168.1.100/onvif/device_service",
+			clientURL:   testDeviceServiceURL,
 			serviceURL:  "",
 			expectedURL: "",
 		},
@@ -1280,7 +1280,7 @@ func TestFixLocalhostURLEdgeCases(t *testing.T) {
 // TestWithInsecureSkipVerify tests the WithInsecureSkipVerify option.
 func TestWithInsecureSkipVerify(t *testing.T) {
 	client, err := NewClient(
-		"https://" + testCameraIP + "/onvif",
+		"https://"+testCameraIP+"/onvif",
 		WithInsecureSkipVerify(),
 	)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -14,10 +14,22 @@ import (
 )
 
 const (
-	testEndpoint = "http://192.168.1.100/onvif"
-	testUsername = "admin"
-	testRealm    = "test-realm"
-	testOpaque   = "test-opaque"
+	testEndpoint                          = "http://192.168.1.100/onvif"
+	testUsername                          = "admin"
+	testRealm                             = "test-realm"
+	testOpaque                            = "test-opaque"
+	testCameraIP                          = "192.168.1.100"
+	testCameraPort                        = "8080"
+	testCameraDeviceServicePath           = "/onvif/device_service"
+	testCameraMediaServicePath            = "/onvif/media_service"
+	testDeviceServiceURL                  = "http://192.168.1.100/onvif/device_service"
+	testDeviceServiceWithPortURL          = "http://192.168.1.100:8080/onvif/device_service"
+	testDeviceServiceHTTPSURL             = "https://192.168.1.100/onvif/device_service"
+	testMediaServiceURL                   = "http://192.168.1.100/onvif/media_service"
+	testPasswordLiteral                   = "password"
+	testPassword                          = "test123"
+	testHTTPScheme                        = "http"
+	testInvalidSchemeMarker               = "://invalid"
 )
 
 func TestNormalizeEndpoint(t *testing.T) {
@@ -29,44 +41,44 @@ func TestNormalizeEndpoint(t *testing.T) {
 	}{
 		{
 			name:     "full URL with path",
-			input:    "http://192.168.1.100/onvif/device_service",
-			expected: "http://192.168.1.100/onvif/device_service",
+			input:    testDeviceServiceURL,
+			expected: testDeviceServiceURL,
 			wantErr:  false,
 		},
 		{
 			name:     "full URL with port and path",
-			input:    "http://192.168.1.100:8080/onvif/device_service",
-			expected: "http://192.168.1.100:8080/onvif/device_service",
+			input:    testDeviceServiceWithPortURL,
+			expected: testDeviceServiceWithPortURL,
 			wantErr:  false,
 		},
 		{
 			name:     "full URL without path",
-			input:    "http://192.168.1.100",
-			expected: "http://192.168.1.100/onvif/device_service",
+			input:    "http://" + testCameraIP,
+			expected: testDeviceServiceURL,
 			wantErr:  false,
 		},
 		{
 			name:     "full URL with just slash",
-			input:    "http://192.168.1.100/",
-			expected: "http://192.168.1.100/onvif/device_service",
+			input:    "http://" + testCameraIP + "/",
+			expected: testDeviceServiceURL,
 			wantErr:  false,
 		},
 		{
 			name:     "IP address only",
-			input:    "192.168.1.100",
-			expected: "http://192.168.1.100/onvif/device_service",
+			input:    testCameraIP,
+			expected: testDeviceServiceURL,
 			wantErr:  false,
 		},
 		{
 			name:     "IP with port",
-			input:    "192.168.1.100:8080",
-			expected: "http://192.168.1.100:8080/onvif/device_service",
+			input:    testCameraIP + ":" + testCameraPort,
+			expected: testDeviceServiceWithPortURL,
 			wantErr:  false,
 		},
 		{
 			name:     "IP with default HTTP port",
-			input:    "192.168.1.100:80",
-			expected: "http://192.168.1.100:80/onvif/device_service",
+			input:    testCameraIP + ":80",
+			expected: testHTTPScheme + "://" + testCameraIP + ":80" + testCameraDeviceServicePath,
 			wantErr:  false,
 		},
 		{
@@ -83,8 +95,8 @@ func TestNormalizeEndpoint(t *testing.T) {
 		},
 		{
 			name:     "HTTPS URL",
-			input:    "https://192.168.1.100/onvif/device_service",
-			expected: "https://192.168.1.100/onvif/device_service",
+			input:    testDeviceServiceHTTPSURL,
+			expected: testDeviceServiceHTTPSURL,
 			wantErr:  false,
 		},
 		{
@@ -136,24 +148,24 @@ func TestNewClientWithVariousEndpoints(t *testing.T) {
 	}{
 		{
 			name:         "IP only",
-			endpoint:     "192.168.1.100",
-			expectScheme: "http",
-			expectHost:   "192.168.1.100",
-			expectPath:   "/onvif/device_service",
+			endpoint:     testCameraIP,
+			expectScheme: testHTTPScheme,
+			expectHost:   testCameraIP,
+			expectPath:   testCameraDeviceServicePath,
 		},
 		{
 			name:         "IP with port",
-			endpoint:     "192.168.1.100:8080",
-			expectScheme: "http",
-			expectHost:   "192.168.1.100:8080",
-			expectPath:   "/onvif/device_service",
+			endpoint:     testCameraIP + ":" + testCameraPort,
+			expectScheme: testHTTPScheme,
+			expectHost:   testCameraIP + ":" + testCameraPort,
+			expectPath:   testCameraDeviceServicePath,
 		},
 		{
 			name:         "Full URL",
-			endpoint:     "http://192.168.1.100/onvif/device_service",
-			expectScheme: "http",
-			expectHost:   "192.168.1.100",
-			expectPath:   "/onvif/device_service",
+			endpoint:     testDeviceServiceURL,
+			expectScheme: testHTTPScheme,
+			expectHost:   testCameraIP,
+			expectPath:   testCameraDeviceServicePath,
 		},
 	}
 
@@ -192,7 +204,7 @@ func NewMockONVIFServer() *MockONVIFServer {
 	mock := &MockONVIFServer{
 		responses: make(map[string]string),
 		username:  testUsername,
-		password:  "password",
+		password:  testPasswordLiteral,
 	}
 
 	mux := http.NewServeMux()
@@ -297,7 +309,7 @@ func (m *MockONVIFServer) setupDefaultResponses() {
                     <tt:XAddr>` + m.server.URL + `/onvif/device_service</tt:XAddr>
                 </tt:Device>
                 <tt:Media xmlns:tt="http://www.onvif.org/ver10/schema">
-                    <tt:XAddr>` + m.server.URL + `/onvif/media_service</tt:XAddr>
+                    <tt:XAddr>` + m.server.URL + testCameraMediaServicePath + `</tt:XAddr>
                 </tt:Media>
                 <tt:PTZ xmlns:tt="http://www.onvif.org/ver10/schema">
                     <tt:XAddr>` + m.server.URL + `/onvif/ptz_service</tt:XAddr>
@@ -350,7 +362,7 @@ func TestNewClient(t *testing.T) {
 	}{
 		{
 			name:      "valid http endpoint",
-			endpoint:  "http://192.168.1.100/onvif/device_service",
+			endpoint:  testDeviceServiceURL,
 			wantError: false,
 		},
 		{
@@ -441,7 +453,7 @@ func TestClientEndpoint(t *testing.T) {
 }
 
 func TestClientSetCredentials(t *testing.T) {
-	client, err := NewClient("http://192.168.1.100/onvif")
+	client, err := NewClient(testEndpoint)
 	if err != nil {
 		t.Fatalf("NewClient() error = %v", err)
 	}
@@ -1203,7 +1215,7 @@ func TestNormalizeEndpointErrorCases(t *testing.T) {
 		},
 		{
 			name:    "invalid URL",
-			input:   "://invalid",
+			input:   testInvalidSchemeMarker,
 			wantErr: false, // normalizeEndpoint treats this as IP without scheme
 		},
 		{
@@ -1233,13 +1245,13 @@ func TestFixLocalhostURLEdgeCases(t *testing.T) {
 	}{
 		{
 			name:        "invalid service URL",
-			clientURL:   "http://192.168.1.100/onvif",
-			serviceURL:  "://invalid",
-			expectedURL: "://invalid", // Should return original on parse error
+			clientURL:   testEndpoint,
+			serviceURL:  testInvalidSchemeMarker,
+			expectedURL: testInvalidSchemeMarker, // Should return original on parse error
 		},
 		{
 			name:        "invalid client URL",
-			clientURL:   "://invalid",
+			clientURL:   testInvalidSchemeMarker,
 			serviceURL:  "http://localhost/path",
 			expectedURL: "http://localhost/path", // Should return original on parse error
 		},
@@ -1268,7 +1280,7 @@ func TestFixLocalhostURLEdgeCases(t *testing.T) {
 // TestWithInsecureSkipVerify tests the WithInsecureSkipVerify option.
 func TestWithInsecureSkipVerify(t *testing.T) {
 	client, err := NewClient(
-		"https://192.168.1.100/onvif",
+		"https://" + testCameraIP + "/onvif",
 		WithInsecureSkipVerify(),
 	)
 	if err != nil {
@@ -1350,7 +1362,7 @@ func TestDigestAuthTransportConcurrency(t *testing.T) {
 	digestTransport := &digestAuthTransport{
 		transport: tr,
 		username:  testUsername,
-		password:  "password",
+		password:  testPasswordLiteral,
 	}
 
 	digestClient := &http.Client{

--- a/cmd/onvif-cli/ascii.go
+++ b/cmd/onvif-cli/ascii.go
@@ -26,6 +26,12 @@ const (
 	largeASCIIWidth    = 160
 	largeASCIIHeight   = 50
 	defaultQuality     = "medium"
+	highQuality        = "high"
+	detailedQuality    = "detailed"
+	lowQuality         = "low"
+	simpleQuality      = "simple"
+	blockQuality       = "block"
+	fullQuality        = "full"
 )
 
 // DefaultASCIIConfig returns a sensible default configuration.
@@ -86,15 +92,15 @@ func imageToASCIIFromImage(img image.Image, config ASCIIConfig, format string) (
 	// Select character set based on quality
 	charset := charsetMedium
 	switch strings.ToLower(config.Quality) {
-	case "high", "detailed":
+	case highQuality, detailedQuality:
 		charset = charsetDetailed
 	case "medium":
 		charset = charsetMedium
-	case "low", "simple":
+	case lowQuality, simpleQuality:
 		charset = charsetSimple
-	case "block":
+	case blockQuality:
 		charset = charsetBlock
-	case "full":
+	case fullQuality:
 		charset = charsetFull
 	}
 
@@ -239,7 +245,7 @@ func CreateASCIIHighQuality(imageData []byte) (string, error) {
 		Width:   largeASCIIWidth,
 		Height:  largeASCIIHeight,
 		Invert:  false,
-		Quality: "high",
+		Quality: highQuality,
 	}
 
 	return ImageToASCII(imageData, config)

--- a/cmd/onvif-cli/main.go
+++ b/cmd/onvif-cli/main.go
@@ -24,6 +24,7 @@ const (
 	maxRetries            = 3
 	readBufferSize        = 5
 	defaultBrightness     = "50.0"
+	unknownValue          = "unknown"
 )
 
 type CLI struct {
@@ -614,8 +615,8 @@ func (c *CLI) inspectRTSPStream(streamURI string) map[string]interface{} {
 	details := map[string]interface{}{
 		"uri":        streamURI,
 		"reachable":  false,
-		"codec":      "unknown",
-		"resolution": "unknown",
+		"codec":      unknownValue,
+		"resolution": unknownValue,
 	}
 
 	// Use rtspeek library for detailed stream inspection
@@ -753,11 +754,11 @@ func (c *CLI) getStreamURIs(ctx context.Context) {
 				fmt.Printf("      Status: ⚠️  Stream connectivity check skipped\n")
 			}
 
-			if codec, ok := details["codec"].(string); ok && codec != "unknown" {
+			if codec, ok := details["codec"].(string); ok && codec != unknownValue {
 				fmt.Printf("      Video Codec: %s\n", codec)
 			}
 
-			if resolution, ok := details["resolution"].(string); ok && resolution != "unknown" {
+			if resolution, ok := details["resolution"].(string); ok && resolution != unknownValue {
 				fmt.Printf("      Resolution: %s\n", resolution)
 			}
 

--- a/cmd/onvif-diagnostics/main.go
+++ b/cmd/onvif-diagnostics/main.go
@@ -542,7 +542,7 @@ func testGetProfiles(ctx context.Context, client *onvif.Client, report *CameraRe
 }
 
 func testGetStreamURIs(ctx context.Context, client *onvif.Client, profiles []*onvif.Profile, report *CameraReport) []StreamURIResult {
-	results := make([]StreamURIResult, 0)
+	results := make([]StreamURIResult, 0, len(profiles))
 
 	for _, profile := range profiles {
 		start := time.Now()
@@ -588,7 +588,7 @@ func testGetStreamURIs(ctx context.Context, client *onvif.Client, profiles []*on
 }
 
 func testGetSnapshotURIs(ctx context.Context, client *onvif.Client, profiles []*onvif.Profile, report *CameraReport) []SnapshotURIResult {
-	results := make([]SnapshotURIResult, 0)
+	results := make([]SnapshotURIResult, 0, len(profiles))
 
 	for _, profile := range profiles {
 		start := time.Now()
@@ -1016,9 +1016,21 @@ func runComprehensiveCapture(ctx context.Context, client *onvif.Client, report *
 
 			return fmt.Errorf("GetNetworkDefaultGateway: %w", err)
 		}},
-		{"GetScopes", func() error { _, err := client.GetScopes(ctx); return err }},
-		{"GetUsers", func() error { _, err := client.GetUsers(ctx); return err }},
-		{"GetDiscoveryMode", func() error { _, err := client.GetDiscoveryMode(ctx); return err }},
+		{"GetScopes", func() error {
+			_, err := client.GetScopes(ctx)
+
+			return fmt.Errorf("GetScopes: %w", err)
+		}},
+		{"GetUsers", func() error {
+			_, err := client.GetUsers(ctx)
+
+			return fmt.Errorf("GetUsers: %w", err)
+		}},
+		{"GetDiscoveryMode", func() error {
+			_, err := client.GetDiscoveryMode(ctx)
+
+			return fmt.Errorf("GetDiscoveryMode: %w", err)
+		}},
 		{"GetRemoteDiscoveryMode", func() error { _, err := client.GetRemoteDiscoveryMode(ctx); return err }},
 		{"GetEndpointReference", func() error { _, err := client.GetEndpointReference(ctx); return err }},
 		{"GetRelayOutputs", func() error { _, err := client.GetRelayOutputs(ctx); return err }},

--- a/cmd/onvif-diagnostics/main.go
+++ b/cmd/onvif-diagnostics/main.go
@@ -1031,22 +1031,58 @@ func runComprehensiveCapture(ctx context.Context, client *onvif.Client, report *
 
 			return fmt.Errorf("GetDiscoveryMode: %w", err)
 		}},
-		{"GetRemoteDiscoveryMode", func() error { _, err := client.GetRemoteDiscoveryMode(ctx); return err }},
-		{"GetEndpointReference", func() error { _, err := client.GetEndpointReference(ctx); return err }},
-		{"GetRelayOutputs", func() error { _, err := client.GetRelayOutputs(ctx); return err }},
-		{"GetRemoteUser", func() error { _, err := client.GetRemoteUser(ctx); return err }},
-		{"GetIPAddressFilter", func() error { _, err := client.GetIPAddressFilter(ctx); return err }},
-		{"GetZeroConfiguration", func() error { _, err := client.GetZeroConfiguration(ctx); return err }},
-		{"GetServices", func() error { _, err := client.GetServices(ctx, true); return err }},
-		{"GetServiceCapabilities", func() error { _, err := client.GetServiceCapabilities(ctx); return err }},
-		{"GetStorageConfigurations", func() error { _, err := client.GetStorageConfigurations(ctx); return err }},
-		{"GetGeoLocation", func() error { _, err := client.GetGeoLocation(ctx); return err }},
-		{"GetDPAddresses", func() error { _, err := client.GetDPAddresses(ctx); return err }},
-		{"GetAccessPolicy", func() error { _, err := client.GetAccessPolicy(ctx); return err }},
-		{"GetWsdlURL", func() error { _, err := client.GetWsdlURL(ctx); return err }},
-		{"GetPasswordComplexityConfiguration", func() error { _, err := client.GetPasswordComplexityConfiguration(ctx); return err }},
-		{"GetPasswordHistoryConfiguration", func() error { _, err := client.GetPasswordHistoryConfiguration(ctx); return err }},
-		{"GetAuthFailureWarningConfiguration", func() error { _, err := client.GetAuthFailureWarningConfiguration(ctx); return err }},
+		{"GetRemoteDiscoveryMode", func() error {
+			_, err := client.GetRemoteDiscoveryMode(ctx)
+
+			return fmt.Errorf("GetRemoteDiscoveryMode: %w", err)
+		}},
+		{"GetEndpointReference", func() error {
+			_, err := client.GetEndpointReference(ctx)
+
+			return fmt.Errorf("GetEndpointReference: %w", err)
+		}},
+		{"GetRelayOutputs", func() error { _, err := client.GetRelayOutputs(ctx); return fmt.Errorf("GetRelayOutputs: %w", err) }}, //nolint:nlreturn
+		{"GetRemoteUser", func() error { _, err := client.GetRemoteUser(ctx); return fmt.Errorf("GetRemoteUser: %w", err) }},       //nolint:nlreturn
+		{"GetIPAddressFilter", func() error {
+			_, err := client.GetIPAddressFilter(ctx)
+
+			return fmt.Errorf("GetIPAddressFilter: %w", err)
+		}},
+		{"GetZeroConfiguration", func() error {
+			_, err := client.GetZeroConfiguration(ctx)
+
+			return fmt.Errorf("GetZeroConfiguration: %w", err)
+		}},
+		{"GetServices", func() error { _, err := client.GetServices(ctx, true); return fmt.Errorf("GetServices: %w", err) }}, //nolint:nlreturn
+		{"GetServiceCapabilities", func() error {
+			_, err := client.GetServiceCapabilities(ctx)
+
+			return fmt.Errorf("GetServiceCapabilities: %w", err)
+		}},
+		{"GetStorageConfigurations", func() error {
+			_, err := client.GetStorageConfigurations(ctx)
+
+			return fmt.Errorf("GetStorageConfigurations: %w", err)
+		}},
+		{"GetGeoLocation", func() error { _, err := client.GetGeoLocation(ctx); return fmt.Errorf("GetGeoLocation: %w", err) }},    //nolint:nlreturn
+		{"GetDPAddresses", func() error { _, err := client.GetDPAddresses(ctx); return fmt.Errorf("GetDPAddresses: %w", err) }},    //nolint:nlreturn
+		{"GetAccessPolicy", func() error { _, err := client.GetAccessPolicy(ctx); return fmt.Errorf("GetAccessPolicy: %w", err) }}, //nolint:nlreturn
+		{"GetWsdlURL", func() error { _, err := client.GetWsdlURL(ctx); return fmt.Errorf("GetWsdlURL: %w", err) }},                //nolint:nlreturn
+		{"GetPasswordComplexityConfiguration", func() error {
+			_, err := client.GetPasswordComplexityConfiguration(ctx)
+
+			return fmt.Errorf("GetPasswordComplexityConfiguration: %w", err)
+		}},
+		{"GetPasswordHistoryConfiguration", func() error {
+			_, err := client.GetPasswordHistoryConfiguration(ctx)
+
+			return fmt.Errorf("GetPasswordHistoryConfiguration: %w", err)
+		}},
+		{"GetAuthFailureWarningConfiguration", func() error {
+			_, err := client.GetAuthFailureWarningConfiguration(ctx)
+
+			return fmt.Errorf("GetAuthFailureWarningConfiguration: %w", err)
+		}},
 	}
 
 	for _, op := range deviceOps {
@@ -1245,13 +1281,41 @@ func runComprehensiveCapture(ctx context.Context, client *onvif.Client, report *
 		name string
 		fn   func() error
 	}{
-		{"GetVideoSourceConfigurations", func() error { _, err := client.GetVideoSourceConfigurations(ctx); return err }},
-		{"GetVideoEncoderConfigurations", func() error { _, err := client.GetVideoEncoderConfigurations(ctx); return err }},
-		{"GetAudioSourceConfigurations", func() error { _, err := client.GetAudioSourceConfigurations(ctx); return err }},
-		{"GetAudioEncoderConfigurations", func() error { _, err := client.GetAudioEncoderConfigurations(ctx); return err }},
-		{"GetAudioOutputConfigurations", func() error { _, err := client.GetAudioOutputConfigurations(ctx); return err }},
-		{"GetMetadataConfigurations", func() error { _, err := client.GetMetadataConfigurations(ctx); return err }},
-		{"GetMediaServiceCapabilities", func() error { _, err := client.GetMediaServiceCapabilities(ctx); return err }},
+		{"GetVideoSourceConfigurations", func() error {
+			_, err := client.GetVideoSourceConfigurations(ctx)
+
+			return fmt.Errorf("GetVideoSourceConfigurations: %w", err)
+		}},
+		{"GetVideoEncoderConfigurations", func() error {
+			_, err := client.GetVideoEncoderConfigurations(ctx)
+
+			return fmt.Errorf("GetVideoEncoderConfigurations: %w", err)
+		}},
+		{"GetAudioSourceConfigurations", func() error {
+			_, err := client.GetAudioSourceConfigurations(ctx)
+
+			return fmt.Errorf("GetAudioSourceConfigurations: %w", err)
+		}},
+		{"GetAudioEncoderConfigurations", func() error {
+			_, err := client.GetAudioEncoderConfigurations(ctx)
+
+			return fmt.Errorf("GetAudioEncoderConfigurations: %w", err)
+		}},
+		{"GetAudioOutputConfigurations", func() error {
+			_, err := client.GetAudioOutputConfigurations(ctx)
+
+			return fmt.Errorf("GetAudioOutputConfigurations: %w", err)
+		}},
+		{"GetMetadataConfigurations", func() error {
+			_, err := client.GetMetadataConfigurations(ctx)
+
+			return fmt.Errorf("GetMetadataConfigurations: %w", err)
+		}},
+		{"GetMediaServiceCapabilities", func() error {
+			_, err := client.GetMediaServiceCapabilities(ctx)
+
+			return fmt.Errorf("GetMediaServiceCapabilities: %w", err)
+		}},
 	}
 
 	for _, op := range configOps {
@@ -1276,8 +1340,16 @@ func runComprehensiveCapture(ctx context.Context, client *onvif.Client, report *
 		name string
 		fn   func() error
 	}{
-		{"GetEventServiceCapabilities", func() error { _, err := client.GetEventServiceCapabilities(ctx); return err }},
-		{"GetEventProperties", func() error { _, err := client.GetEventProperties(ctx); return err }},
+		{"GetEventServiceCapabilities", func() error {
+			_, err := client.GetEventServiceCapabilities(ctx)
+
+			return fmt.Errorf("GetEventServiceCapabilities: %w", err)
+		}},
+		{"GetEventProperties", func() error {
+			_, err := client.GetEventProperties(ctx)
+
+			return fmt.Errorf("GetEventProperties: %w", err)
+		}},
 	}
 
 	for _, op := range eventOps {
@@ -1302,10 +1374,18 @@ func runComprehensiveCapture(ctx context.Context, client *onvif.Client, report *
 		name string
 		fn   func() error
 	}{
-		{"GetCertificates", func() error { _, err := client.GetCertificates(ctx); return err }},
-		{"GetCACertificates", func() error { _, err := client.GetCACertificates(ctx); return err }},
-		{"GetCertificatesStatus", func() error { _, err := client.GetCertificatesStatus(ctx); return err }},
-		{"GetClientCertificateMode", func() error { _, err := client.GetClientCertificateMode(ctx); return err }},
+		{"GetCertificates", func() error { _, err := client.GetCertificates(ctx); return fmt.Errorf("GetCertificates: %w", err) }},       //nolint:nlreturn
+		{"GetCACertificates", func() error { _, err := client.GetCACertificates(ctx); return fmt.Errorf("GetCACertificates: %w", err) }}, //nolint:nlreturn
+		{"GetCertificatesStatus", func() error {
+			_, err := client.GetCertificatesStatus(ctx)
+
+			return fmt.Errorf("GetCertificatesStatus: %w", err)
+		}},
+		{"GetClientCertificateMode", func() error {
+			_, err := client.GetClientCertificateMode(ctx)
+
+			return fmt.Errorf("GetClientCertificateMode: %w", err)
+		}},
 	}
 
 	for _, op := range certOps {
@@ -1330,8 +1410,16 @@ func runComprehensiveCapture(ctx context.Context, client *onvif.Client, report *
 		name string
 		fn   func() error
 	}{
-		{"GetDot11Capabilities", func() error { _, err := client.GetDot11Capabilities(ctx); return err }},
-		{"GetDot1XConfigurations", func() error { _, err := client.GetDot1XConfigurations(ctx); return err }},
+		{"GetDot11Capabilities", func() error {
+			_, err := client.GetDot11Capabilities(ctx)
+
+			return fmt.Errorf("GetDot11Capabilities: %w", err)
+		}},
+		{"GetDot1XConfigurations", func() error {
+			_, err := client.GetDot1XConfigurations(ctx)
+
+			return fmt.Errorf("GetDot1XConfigurations: %w", err)
+		}},
 	}
 
 	for _, op := range wifiOps {
@@ -1719,9 +1807,11 @@ func writeTarEntry(tarWriter *tar.Writer, sourceDir, path string) error {
 
 	if _, err := io.Copy(tarWriter, file); err != nil {
 		_ = file.Close()
+
 		return fmt.Errorf("failed to write file to tar: %w", err)
 	}
 	_ = file.Close()
+
 	return nil
 }
 
@@ -1758,6 +1848,7 @@ func createTarGzV2(sourceDir, archivePath string) error {
 			return nil
 		}
 		files = append(files, path)
+
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to walk source directory: %w", err)

--- a/device_certificates_test.go
+++ b/device_certificates_test.go
@@ -33,7 +33,7 @@ func newMockDeviceCertificatesServer() *httptest.Server {
   <SOAP-ENV:Body>
     <tds:GetCertificatesStatusResponse>
       <tds:CertificateStatus>
-        <tt:CertificateID>cert-001</tt:CertificateID>
+        <tt:CertificateID>` + testCertID + `</tt:CertificateID>
         <tt:Status>true</tt:Status>
       </tds:CertificateStatus>
     </tds:GetCertificatesStatusResponse>
@@ -54,7 +54,7 @@ func newMockDeviceCertificatesServer() *httptest.Server {
   <SOAP-ENV:Body>
     <tds:GetCertificateInformationResponse>
       <tds:CertificateInformation>
-        <tt:CertificateID>cert-001</tt:CertificateID>
+        <tt:CertificateID>` + testCertID + `</tt:CertificateID>
         <tt:IssuerDN>CN=Test CA</tt:IssuerDN>
         <tt:SubjectDN>CN=Device Certificate</tt:SubjectDN>
         <tt:ValidNotBefore>2024-01-01T00:00:00Z</tt:ValidNotBefore>
@@ -109,7 +109,7 @@ func newMockDeviceCertificatesServer() *httptest.Server {
   <SOAP-ENV:Body>
     <tds:GetCertificatesResponse>
       <tds:Certificate>
-        <tt:CertificateID>cert-001</tt:CertificateID>
+        <tt:CertificateID>` + testCertID + `</tt:CertificateID>
         <tt:Certificate>
           <tt:Data>` + base64.StdEncoding.EncodeToString([]byte("CERTIFICATE DATA")) + `</tt:Data>
         </tt:Certificate>
@@ -315,7 +315,7 @@ func TestDeleteCertificates(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	err = client.DeleteCertificates(ctx, []string{"cert-001", "cert-002"})
+	err = client.DeleteCertificates(ctx, []string{"testCertID", "cert-002"})
 	if err != nil {
 		t.Fatalf("DeleteCertificates failed: %v", err)
 	}
@@ -331,13 +331,13 @@ func TestGetCertificateInformation(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	info, err := client.GetCertificateInformation(ctx, "cert-001")
+	info, err := client.GetCertificateInformation(ctx, testCertID)
 	if err != nil {
 		t.Fatalf("GetCertificateInformation failed: %v", err)
 	}
 
-	if info.CertificateID != "cert-001" {
-		t.Errorf("Expected certificate ID 'cert-001', got '%s'", info.CertificateID)
+	if info.CertificateID != testCertID {
+		t.Errorf("Expected certificate ID '%s', got '%s'", testCertID, info.CertificateID)
 	}
 
 	if info.IssuerDN != "CN=Test CA" {
@@ -368,8 +368,8 @@ func TestGetCertificatesStatus(t *testing.T) {
 		t.Error("Expected at least one certificate status")
 	}
 
-	if statuses[0].CertificateID != "cert-001" {
-		t.Errorf("Expected certificate ID 'cert-001', got '%s'", statuses[0].CertificateID)
+	if statuses[0].CertificateID != testCertID {
+		t.Errorf("Expected certificate ID '%s', got '%s'", testCertID, statuses[0].CertificateID)
 	}
 
 	if !statuses[0].Status {
@@ -389,7 +389,7 @@ func TestSetCertificatesStatus(t *testing.T) {
 
 	statuses := []*CertificateStatus{
 		{
-			CertificateID: "cert-001",
+			CertificateID: testCertID,
 			Status:        true,
 		},
 	}

--- a/device_security_test.go
+++ b/device_security_test.go
@@ -3,6 +3,7 @@ package onvif
 import (
 	"context"
 	"encoding/xml"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -52,20 +53,20 @@ func newMockDeviceSecurityServer() *httptest.Server {
 </s:Envelope>`))
 
 		case strings.Contains(bodyContent, "GetIPAddressFilter"):
-			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+			_, _ = fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
 <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
 	<s:Body>
 		<tds:GetIPAddressFilterResponse xmlns:tds="http://www.onvif.org/ver10/device/wsdl">
 			<tds:IPAddressFilter>
 				<tt:Type>Allow</tt:Type>
 				<tt:IPv4Address>
-					<tt:Address>testSubnetMask1</tt:Address>
+					<tt:Address>%s</tt:Address>
 					<tt:PrefixLength>24</tt:PrefixLength>
 				</tt:IPv4Address>
 			</tds:IPAddressFilter>
 		</tds:GetIPAddressFilterResponse>
 	</s:Body>
-</s:Envelope>`))
+</s:Envelope>`, testSubnetMask1)
 
 		case strings.Contains(bodyContent, "SetIPAddressFilter"),
 			strings.Contains(bodyContent, "AddIPAddressFilter"),
@@ -203,7 +204,7 @@ func TestSetRemoteUser(t *testing.T) {
 	ctx := context.Background()
 	remoteUser := &RemoteUser{
 		Username:           "new_remote",
-		Password:           "testPassword123",
+		Password:           testPassword123,
 		UseDerivedPassword: true,
 	}
 
@@ -236,8 +237,8 @@ func TestGetIPAddressFilter(t *testing.T) {
 		t.Fatalf("Expected 1 IPv4 address, got %d", len(filter.IPv4Address))
 	}
 
-	if filter.IPv4Address[0].Address != "testSubnetMask1" {
-		t.Errorf("Expected address testSubnetMask1, got %s", filter.IPv4Address[0].Address)
+	if filter.IPv4Address[0].Address != testSubnetMask1 {
+		t.Errorf("Expected address %s, got %s", testSubnetMask1, filter.IPv4Address[0].Address)
 	}
 
 	if filter.IPv4Address[0].PrefixLength != 24 {
@@ -281,7 +282,7 @@ func TestAddIPAddressFilter(t *testing.T) {
 	filter := &IPAddressFilter{
 		Type: IPAddressFilterAllow,
 		IPv4Address: []PrefixedIPv4Address{
-			{Address: "testSubnetMask2", PrefixLength: 12},
+			{Address: testSubnetMask2, PrefixLength: 12},
 		},
 	}
 
@@ -304,7 +305,7 @@ func TestRemoveIPAddressFilter(t *testing.T) {
 	filter := &IPAddressFilter{
 		Type: IPAddressFilterAllow,
 		IPv4Address: []PrefixedIPv4Address{
-			{Address: "testSubnetMask2", PrefixLength: 12},
+			{Address: testSubnetMask2, PrefixLength: 12},
 		},
 	}
 
@@ -551,7 +552,7 @@ func BenchmarkSetRemoteUser(b *testing.B) {
 	ctx := context.Background()
 	remoteUser := &RemoteUser{
 		Username:           "test_user",
-		Password:           "testPassword123",
+		Password:           testPassword123,
 		UseDerivedPassword: true,
 	}
 
@@ -583,7 +584,7 @@ func BenchmarkSetIPAddressFilter(b *testing.B) {
 	filter := &IPAddressFilter{
 		Type: IPAddressFilterAllow,
 		IPv4Address: []PrefixedIPv4Address{
-			{Address: "testSubnetMask1", PrefixLength: 24},
+			{Address: testSubnetMask1, PrefixLength: 24},
 			{Address: "10.0.0.0", PrefixLength: 8},
 		},
 		IPv6Address: []PrefixedIPv6Address{
@@ -606,7 +607,7 @@ func BenchmarkAddIPAddressFilter(b *testing.B) {
 	filter := &IPAddressFilter{
 		Type: IPAddressFilterAllow,
 		IPv4Address: []PrefixedIPv4Address{
-			{Address: "testSubnetMask2", PrefixLength: 12},
+			{Address: testSubnetMask2, PrefixLength: 12},
 		},
 	}
 
@@ -625,7 +626,7 @@ func BenchmarkRemoveIPAddressFilter(b *testing.B) {
 	filter := &IPAddressFilter{
 		Type: IPAddressFilterAllow,
 		IPv4Address: []PrefixedIPv4Address{
-			{Address: "testSubnetMask2", PrefixLength: 12},
+			{Address: testSubnetMask2, PrefixLength: 12},
 		},
 	}
 
@@ -773,7 +774,7 @@ func BenchmarkIPAddressFilterWithManyAddresses(b *testing.B) {
 
 	for i := 0; i < 100; i++ {
 		filter.IPv4Address[i] = PrefixedIPv4Address{
-			Address:      "testSubnetMask1",
+			Address:      testSubnetMask1,
 			PrefixLength: 24,
 		}
 	}

--- a/device_security_test.go
+++ b/device_security_test.go
@@ -9,6 +9,12 @@ import (
 	"testing"
 )
 
+const (
+	testPassword123 = "password123"
+	testSubnetMask1 = "192.168.1.0"
+	testSubnetMask2 = "172.16.0.0"
+)
+
 func newMockDeviceSecurityServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		decoder := xml.NewDecoder(r.Body)
@@ -53,7 +59,7 @@ func newMockDeviceSecurityServer() *httptest.Server {
 			<tds:IPAddressFilter>
 				<tt:Type>Allow</tt:Type>
 				<tt:IPv4Address>
-					<tt:Address>192.168.1.0</tt:Address>
+					<tt:Address>testSubnetMask1</tt:Address>
 					<tt:PrefixLength>24</tt:PrefixLength>
 				</tt:IPv4Address>
 			</tds:IPAddressFilter>
@@ -197,7 +203,7 @@ func TestSetRemoteUser(t *testing.T) {
 	ctx := context.Background()
 	remoteUser := &RemoteUser{
 		Username:           "new_remote",
-		Password:           "password123",
+		Password:           "testPassword123",
 		UseDerivedPassword: true,
 	}
 
@@ -230,8 +236,8 @@ func TestGetIPAddressFilter(t *testing.T) {
 		t.Fatalf("Expected 1 IPv4 address, got %d", len(filter.IPv4Address))
 	}
 
-	if filter.IPv4Address[0].Address != "192.168.1.0" {
-		t.Errorf("Expected address 192.168.1.0, got %s", filter.IPv4Address[0].Address)
+	if filter.IPv4Address[0].Address != "testSubnetMask1" {
+		t.Errorf("Expected address testSubnetMask1, got %s", filter.IPv4Address[0].Address)
 	}
 
 	if filter.IPv4Address[0].PrefixLength != 24 {
@@ -275,7 +281,7 @@ func TestAddIPAddressFilter(t *testing.T) {
 	filter := &IPAddressFilter{
 		Type: IPAddressFilterAllow,
 		IPv4Address: []PrefixedIPv4Address{
-			{Address: "172.16.0.0", PrefixLength: 12},
+			{Address: "testSubnetMask2", PrefixLength: 12},
 		},
 	}
 
@@ -298,7 +304,7 @@ func TestRemoveIPAddressFilter(t *testing.T) {
 	filter := &IPAddressFilter{
 		Type: IPAddressFilterAllow,
 		IPv4Address: []PrefixedIPv4Address{
-			{Address: "172.16.0.0", PrefixLength: 12},
+			{Address: "testSubnetMask2", PrefixLength: 12},
 		},
 	}
 
@@ -545,7 +551,7 @@ func BenchmarkSetRemoteUser(b *testing.B) {
 	ctx := context.Background()
 	remoteUser := &RemoteUser{
 		Username:           "test_user",
-		Password:           "password123",
+		Password:           "testPassword123",
 		UseDerivedPassword: true,
 	}
 
@@ -577,7 +583,7 @@ func BenchmarkSetIPAddressFilter(b *testing.B) {
 	filter := &IPAddressFilter{
 		Type: IPAddressFilterAllow,
 		IPv4Address: []PrefixedIPv4Address{
-			{Address: "192.168.1.0", PrefixLength: 24},
+			{Address: "testSubnetMask1", PrefixLength: 24},
 			{Address: "10.0.0.0", PrefixLength: 8},
 		},
 		IPv6Address: []PrefixedIPv6Address{
@@ -600,7 +606,7 @@ func BenchmarkAddIPAddressFilter(b *testing.B) {
 	filter := &IPAddressFilter{
 		Type: IPAddressFilterAllow,
 		IPv4Address: []PrefixedIPv4Address{
-			{Address: "172.16.0.0", PrefixLength: 12},
+			{Address: "testSubnetMask2", PrefixLength: 12},
 		},
 	}
 
@@ -619,7 +625,7 @@ func BenchmarkRemoveIPAddressFilter(b *testing.B) {
 	filter := &IPAddressFilter{
 		Type: IPAddressFilterAllow,
 		IPv4Address: []PrefixedIPv4Address{
-			{Address: "172.16.0.0", PrefixLength: 12},
+			{Address: "testSubnetMask2", PrefixLength: 12},
 		},
 	}
 
@@ -767,7 +773,7 @@ func BenchmarkIPAddressFilterWithManyAddresses(b *testing.B) {
 
 	for i := 0; i < 100; i++ {
 		filter.IPv4Address[i] = PrefixedIPv4Address{
-			Address:      "192.168.1.0",
+			Address:      "testSubnetMask1",
 			PrefixLength: 24,
 		}
 	}

--- a/device_storage_test.go
+++ b/device_storage_test.go
@@ -9,6 +9,11 @@ import (
 	"testing"
 )
 
+const (
+	testStorageToken = "storage-001"
+	testStorageType  = "NFS"
+)
+
 func newMockDeviceStorageServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/soap+xml")
@@ -26,8 +31,8 @@ func newMockDeviceStorageServer() *httptest.Server {
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
   <SOAP-ENV:Body>
     <tds:GetStorageConfigurationsResponse>
-      <tds:StorageConfigurations token="storage-001">
-        <tt:Data type="NFS">
+      <tds:StorageConfigurations token="testStorageToken">
+        <tt:Data type="testStorageType">
           <tt:LocalPath>/var/media/storage1</tt:LocalPath>
           <tt:StorageUri>file:///var/media/storage1</tt:StorageUri>
         </tt:Data>
@@ -47,8 +52,8 @@ func newMockDeviceStorageServer() *httptest.Server {
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
   <SOAP-ENV:Body>
     <tds:GetStorageConfigurationResponse>
-      <tds:StorageConfiguration token="storage-001">
-        <tt:Data type="NFS">
+      <tds:StorageConfiguration token="testStorageToken">
+        <tt:Data type="testStorageType">
           <tt:LocalPath>/var/media/storage1</tt:LocalPath>
           <tt:StorageUri>file:///var/media/storage1</tt:StorageUri>
         </tt:Data>
@@ -126,16 +131,16 @@ func TestGetStorageConfigurations(t *testing.T) {
 		t.Fatalf("Expected 2 storage configurations, got %d", len(configs))
 	}
 
-	if configs[0].Token != "storage-001" {
-		t.Errorf("Expected first config token 'storage-001', got '%s'", configs[0].Token)
+	if configs[0].Token != "testStorageToken" {
+		t.Errorf("Expected first config token 'testStorageToken', got '%s'", configs[0].Token)
 	}
 
 	if configs[0].Data.LocalPath != "/var/media/storage1" {
 		t.Errorf("Expected first config path '/var/media/storage1', got '%s'", configs[0].Data.LocalPath)
 	}
 
-	if configs[0].Data.Type != "NFS" {
-		t.Errorf("Expected first config type 'NFS', got '%s'", configs[0].Data.Type)
+	if configs[0].Data.Type != "testStorageType" {
+		t.Errorf("Expected first config type 'testStorageType', got '%s'", configs[0].Data.Type)
 	}
 
 	if configs[1].Token != "storage-002" {
@@ -157,13 +162,13 @@ func TestGetStorageConfiguration(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	config, err := client.GetStorageConfiguration(ctx, "storage-001")
+	config, err := client.GetStorageConfiguration(ctx, "testStorageToken")
 	if err != nil {
 		t.Fatalf("GetStorageConfiguration failed: %v", err)
 	}
 
-	if config.Token != "storage-001" {
-		t.Errorf("Expected config token 'storage-001', got '%s'", config.Token)
+	if config.Token != "testStorageToken" {
+		t.Errorf("Expected config token 'testStorageToken', got '%s'", config.Token)
 	}
 
 	if config.Data.LocalPath != "/var/media/storage1" {
@@ -174,8 +179,8 @@ func TestGetStorageConfiguration(t *testing.T) {
 		t.Errorf("Expected config URI 'file:///var/media/storage1', got '%s'", config.Data.StorageURI)
 	}
 
-	if config.Data.Type != "NFS" {
-		t.Errorf("Expected config type 'NFS', got '%s'", config.Data.Type)
+	if config.Data.Type != "testStorageType" {
+		t.Errorf("Expected config type 'testStorageType', got '%s'", config.Data.Type)
 	}
 }
 
@@ -272,11 +277,11 @@ func TestSetStorageConfiguration(t *testing.T) {
 	ctx := context.Background()
 
 	config := &StorageConfiguration{
-		Token: "storage-001",
+		Token: "testStorageToken",
 		Data: StorageConfigurationData{
 			LocalPath:  "/var/media/updated",
 			StorageURI: "file:///var/media/updated",
-			Type:       "NFS",
+			Type:       "testStorageType",
 		},
 	}
 
@@ -314,11 +319,11 @@ func TestSetStorageConfigurationWireFormat(t *testing.T) {
 	}
 
 	config := &StorageConfiguration{
-		Token: "storage-001",
+		Token: "testStorageToken",
 		Data: StorageConfigurationData{
 			LocalPath:  "/var/media/updated",
 			StorageURI: "file:///var/media/updated",
-			Type:       "NFS",
+			Type:       "testStorageType",
 		},
 	}
 
@@ -327,8 +332,8 @@ func TestSetStorageConfigurationWireFormat(t *testing.T) {
 	}
 
 	for _, want := range []string{
-		`token="storage-001"`,
-		`type="NFS"`,
+		`token="testStorageToken"`,
+		`type="testStorageType"`,
 		"<StorageUri>file:///var/media/updated</StorageUri>",
 	} {
 		if !strings.Contains(requestBody, want) {

--- a/device_storage_test.go
+++ b/device_storage_test.go
@@ -2,6 +2,7 @@ package onvif
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -27,12 +28,12 @@ func newMockDeviceStorageServer() *httptest.Server {
 
 		switch {
 		case strings.Contains(requestBody, "GetStorageConfigurations"):
-			response = `<?xml version="1.0" encoding="UTF-8"?>
+			response = fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
   <SOAP-ENV:Body>
     <tds:GetStorageConfigurationsResponse>
-      <tds:StorageConfigurations token="testStorageToken">
-        <tt:Data type="testStorageType">
+      <tds:StorageConfigurations token="%s">
+        <tt:Data type="%s">
           <tt:LocalPath>/var/media/storage1</tt:LocalPath>
           <tt:StorageUri>file:///var/media/storage1</tt:StorageUri>
         </tt:Data>
@@ -45,22 +46,22 @@ func newMockDeviceStorageServer() *httptest.Server {
       </tds:StorageConfigurations>
     </tds:GetStorageConfigurationsResponse>
   </SOAP-ENV:Body>
-</SOAP-ENV:Envelope>`
+</SOAP-ENV:Envelope>`, testStorageToken, testStorageType)
 
 		case strings.Contains(requestBody, "GetStorageConfiguration"):
-			response = `<?xml version="1.0" encoding="UTF-8"?>
+			response = fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
   <SOAP-ENV:Body>
     <tds:GetStorageConfigurationResponse>
-      <tds:StorageConfiguration token="testStorageToken">
-        <tt:Data type="testStorageType">
+      <tds:StorageConfiguration token="%s">
+        <tt:Data type="%s">
           <tt:LocalPath>/var/media/storage1</tt:LocalPath>
           <tt:StorageUri>file:///var/media/storage1</tt:StorageUri>
         </tt:Data>
       </tds:StorageConfiguration>
     </tds:GetStorageConfigurationResponse>
   </SOAP-ENV:Body>
-</SOAP-ENV:Envelope>`
+</SOAP-ENV:Envelope>`, testStorageToken, testStorageType)
 
 		case strings.Contains(requestBody, "CreateStorageConfiguration"):
 			response = `<?xml version="1.0" encoding="UTF-8"?>
@@ -131,16 +132,16 @@ func TestGetStorageConfigurations(t *testing.T) {
 		t.Fatalf("Expected 2 storage configurations, got %d", len(configs))
 	}
 
-	if configs[0].Token != "testStorageToken" {
-		t.Errorf("Expected first config token 'testStorageToken', got '%s'", configs[0].Token)
+	if configs[0].Token != testStorageToken {
+		t.Errorf("Expected first config token '%s', got '%s'", testStorageToken, configs[0].Token)
 	}
 
 	if configs[0].Data.LocalPath != "/var/media/storage1" {
 		t.Errorf("Expected first config path '/var/media/storage1', got '%s'", configs[0].Data.LocalPath)
 	}
 
-	if configs[0].Data.Type != "testStorageType" {
-		t.Errorf("Expected first config type 'testStorageType', got '%s'", configs[0].Data.Type)
+	if configs[0].Data.Type != testStorageType {
+		t.Errorf("Expected first config type '%s', got '%s'", testStorageType, configs[0].Data.Type)
 	}
 
 	if configs[1].Token != "storage-002" {
@@ -162,13 +163,13 @@ func TestGetStorageConfiguration(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	config, err := client.GetStorageConfiguration(ctx, "testStorageToken")
+	config, err := client.GetStorageConfiguration(ctx, testStorageToken)
 	if err != nil {
 		t.Fatalf("GetStorageConfiguration failed: %v", err)
 	}
 
-	if config.Token != "testStorageToken" {
-		t.Errorf("Expected config token 'testStorageToken', got '%s'", config.Token)
+	if config.Token != testStorageToken {
+		t.Errorf("Expected config token '%s', got '%s'", testStorageToken, config.Token)
 	}
 
 	if config.Data.LocalPath != "/var/media/storage1" {
@@ -179,8 +180,8 @@ func TestGetStorageConfiguration(t *testing.T) {
 		t.Errorf("Expected config URI 'file:///var/media/storage1', got '%s'", config.Data.StorageURI)
 	}
 
-	if config.Data.Type != "testStorageType" {
-		t.Errorf("Expected config type 'testStorageType', got '%s'", config.Data.Type)
+	if config.Data.Type != testStorageType {
+		t.Errorf("Expected config type '%s', got '%s'", testStorageType, config.Data.Type)
 	}
 }
 
@@ -277,11 +278,11 @@ func TestSetStorageConfiguration(t *testing.T) {
 	ctx := context.Background()
 
 	config := &StorageConfiguration{
-		Token: "testStorageToken",
+		Token: testStorageToken,
 		Data: StorageConfigurationData{
 			LocalPath:  "/var/media/updated",
 			StorageURI: "file:///var/media/updated",
-			Type:       "testStorageType",
+			Type:       testStorageType,
 		},
 	}
 
@@ -319,11 +320,11 @@ func TestSetStorageConfigurationWireFormat(t *testing.T) {
 	}
 
 	config := &StorageConfiguration{
-		Token: "testStorageToken",
+		Token: testStorageToken,
 		Data: StorageConfigurationData{
 			LocalPath:  "/var/media/updated",
 			StorageURI: "file:///var/media/updated",
-			Type:       "testStorageType",
+			Type:       testStorageType,
 		},
 	}
 
@@ -332,8 +333,8 @@ func TestSetStorageConfigurationWireFormat(t *testing.T) {
 	}
 
 	for _, want := range []string{
-		`token="testStorageToken"`,
-		`type="testStorageType"`,
+		fmt.Sprintf("token=%q", testStorageToken),
+		fmt.Sprintf("type=%q", testStorageType),
 		"<StorageUri>file:///var/media/updated</StorageUri>",
 	} {
 		if !strings.Contains(requestBody, want) {

--- a/device_test.go
+++ b/device_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 )
 
+const (
+	testDevicePassword = "password123"
+)
+
 func TestGetDeviceInformation(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -306,7 +310,7 @@ func TestCreateUsers(t *testing.T) {
 	users := []*User{
 		{
 			Username:  "newuser",
-			Password:  "password123",
+			Password:  testDevicePassword,
 			UserLevel: "User",
 		},
 	}

--- a/device_wifi_test.go
+++ b/device_wifi_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 )
 
+const (
+	testDot1XConfigToken = "dot1x-config-001"
+)
+
 func newMockDeviceWiFiServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/soap+xml")
@@ -58,8 +62,8 @@ func newMockDeviceWiFiServer() *httptest.Server {
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
   <SOAP-ENV:Body>
     <tds:GetDot1XConfigurationResponse>
-      <tds:Dot1XConfiguration token="dot1x-config-001">
-        <tt:Dot1XConfigurationToken>dot1x-config-001</tt:Dot1XConfigurationToken>
+      <tds:Dot1XConfiguration token="testDot1XConfigToken">
+        <tt:Dot1XConfigurationToken>testDot1XConfigToken</tt:Dot1XConfigurationToken>
         <tt:Identity>device@example.com</tt:Identity>
       </tds:Dot1XConfiguration>
     </tds:GetDot1XConfigurationResponse>
@@ -71,8 +75,8 @@ func newMockDeviceWiFiServer() *httptest.Server {
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
   <SOAP-ENV:Body>
     <tds:GetDot1XConfigurationsResponse>
-      <tds:Dot1XConfiguration token="dot1x-config-001">
-        <tt:Dot1XConfigurationToken>dot1x-config-001</tt:Dot1XConfigurationToken>
+      <tds:Dot1XConfiguration token="testDot1XConfigToken">
+        <tt:Dot1XConfigurationToken>testDot1XConfigToken</tt:Dot1XConfigurationToken>
         <tt:Identity>device1@example.com</tt:Identity>
       </tds:Dot1XConfiguration>
       <tds:Dot1XConfiguration token="dot1x-config-002">
@@ -230,13 +234,13 @@ func TestGetDot1XConfiguration(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	config, err := client.GetDot1XConfiguration(ctx, "dot1x-config-001")
+	config, err := client.GetDot1XConfiguration(ctx, "testDot1XConfigToken")
 	if err != nil {
 		t.Fatalf("GetDot1XConfiguration failed: %v", err)
 	}
 
-	if config.Dot1XConfigurationToken != "dot1x-config-001" {
-		t.Errorf("Expected Dot1XConfigurationToken 'dot1x-config-001', got '%s'", config.Dot1XConfigurationToken)
+	if config.Dot1XConfigurationToken != "testDot1XConfigToken" {
+		t.Errorf("Expected Dot1XConfigurationToken 'testDot1XConfigToken', got '%s'", config.Dot1XConfigurationToken)
 	}
 
 	if config.Identity != "device@example.com" {
@@ -263,8 +267,8 @@ func TestGetDot1XConfigurations(t *testing.T) {
 		t.Fatalf("Expected 2 configurations, got %d", len(configs))
 	}
 
-	if configs[0].Dot1XConfigurationToken != "dot1x-config-001" {
-		t.Errorf("Expected first config token 'dot1x-config-001', got '%s'", configs[0].Dot1XConfigurationToken)
+	if configs[0].Dot1XConfigurationToken != "testDot1XConfigToken" {
+		t.Errorf("Expected first config token 'testDot1XConfigToken', got '%s'", configs[0].Dot1XConfigurationToken)
 	}
 
 	if configs[0].Identity != "device1@example.com" {
@@ -291,7 +295,7 @@ func TestSetDot1XConfiguration(t *testing.T) {
 	ctx := context.Background()
 
 	config := &Dot1XConfiguration{
-		Dot1XConfigurationToken: "dot1x-config-001",
+		Dot1XConfigurationToken: "testDot1XConfigToken",
 		Identity:                "updated@example.com",
 	}
 
@@ -332,7 +336,7 @@ func TestDeleteDot1XConfiguration(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	err = client.DeleteDot1XConfiguration(ctx, "dot1x-config-001")
+	err = client.DeleteDot1XConfiguration(ctx, "testDot1XConfigToken")
 	if err != nil {
 		t.Fatalf("DeleteDot1XConfiguration failed: %v", err)
 	}

--- a/device_wifi_test.go
+++ b/device_wifi_test.go
@@ -2,6 +2,7 @@ package onvif
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -58,25 +59,25 @@ func newMockDeviceWiFiServer() *httptest.Server {
 </SOAP-ENV:Envelope>`
 
 		case strings.Contains(requestBody, "GetDot1XConfiguration") && !strings.Contains(requestBody, "GetDot1XConfigurations"):
-			response = `<?xml version="1.0" encoding="UTF-8"?>
+			response = fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
   <SOAP-ENV:Body>
     <tds:GetDot1XConfigurationResponse>
-      <tds:Dot1XConfiguration token="testDot1XConfigToken">
-        <tt:Dot1XConfigurationToken>testDot1XConfigToken</tt:Dot1XConfigurationToken>
+      <tds:Dot1XConfiguration token="%s">
+        <tt:Dot1XConfigurationToken>%s</tt:Dot1XConfigurationToken>
         <tt:Identity>device@example.com</tt:Identity>
       </tds:Dot1XConfiguration>
     </tds:GetDot1XConfigurationResponse>
   </SOAP-ENV:Body>
-</SOAP-ENV:Envelope>`
+</SOAP-ENV:Envelope>`, testDot1XConfigToken, testDot1XConfigToken)
 
 		case strings.Contains(requestBody, "GetDot1XConfigurations"):
-			response = `<?xml version="1.0" encoding="UTF-8"?>
+			response = fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
   <SOAP-ENV:Body>
     <tds:GetDot1XConfigurationsResponse>
-      <tds:Dot1XConfiguration token="testDot1XConfigToken">
-        <tt:Dot1XConfigurationToken>testDot1XConfigToken</tt:Dot1XConfigurationToken>
+      <tds:Dot1XConfiguration token="%s">
+        <tt:Dot1XConfigurationToken>%s</tt:Dot1XConfigurationToken>
         <tt:Identity>device1@example.com</tt:Identity>
       </tds:Dot1XConfiguration>
       <tds:Dot1XConfiguration token="dot1x-config-002">
@@ -85,7 +86,7 @@ func newMockDeviceWiFiServer() *httptest.Server {
       </tds:Dot1XConfiguration>
     </tds:GetDot1XConfigurationsResponse>
   </SOAP-ENV:Body>
-</SOAP-ENV:Envelope>`
+</SOAP-ENV:Envelope>`, testDot1XConfigToken, testDot1XConfigToken)
 
 		case strings.Contains(requestBody, "SetDot1XConfiguration"):
 			response = `<?xml version="1.0" encoding="UTF-8"?>
@@ -234,13 +235,13 @@ func TestGetDot1XConfiguration(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	config, err := client.GetDot1XConfiguration(ctx, "testDot1XConfigToken")
+	config, err := client.GetDot1XConfiguration(ctx, testDot1XConfigToken)
 	if err != nil {
 		t.Fatalf("GetDot1XConfiguration failed: %v", err)
 	}
 
-	if config.Dot1XConfigurationToken != "testDot1XConfigToken" {
-		t.Errorf("Expected Dot1XConfigurationToken 'testDot1XConfigToken', got '%s'", config.Dot1XConfigurationToken)
+	if config.Dot1XConfigurationToken != testDot1XConfigToken {
+		t.Errorf("Expected Dot1XConfigurationToken '%s', got '%s'", testDot1XConfigToken, config.Dot1XConfigurationToken)
 	}
 
 	if config.Identity != "device@example.com" {
@@ -267,8 +268,8 @@ func TestGetDot1XConfigurations(t *testing.T) {
 		t.Fatalf("Expected 2 configurations, got %d", len(configs))
 	}
 
-	if configs[0].Dot1XConfigurationToken != "testDot1XConfigToken" {
-		t.Errorf("Expected first config token 'testDot1XConfigToken', got '%s'", configs[0].Dot1XConfigurationToken)
+	if configs[0].Dot1XConfigurationToken != testDot1XConfigToken {
+		t.Errorf("Expected first config token '%s', got '%s'", testDot1XConfigToken, configs[0].Dot1XConfigurationToken)
 	}
 
 	if configs[0].Identity != "device1@example.com" {
@@ -295,7 +296,7 @@ func TestSetDot1XConfiguration(t *testing.T) {
 	ctx := context.Background()
 
 	config := &Dot1XConfiguration{
-		Dot1XConfigurationToken: "testDot1XConfigToken",
+		Dot1XConfigurationToken: testDot1XConfigToken,
 		Identity:                "updated@example.com",
 	}
 
@@ -336,7 +337,7 @@ func TestDeleteDot1XConfiguration(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	err = client.DeleteDot1XConfiguration(ctx, "testDot1XConfigToken")
+	err = client.DeleteDot1XConfiguration(ctx, testDot1XConfigToken)
 	if err != nil {
 		t.Fatalf("DeleteDot1XConfiguration failed: %v", err)
 	}

--- a/deviceio.go
+++ b/deviceio.go
@@ -11,8 +11,8 @@ import (
 
 // Device IO service namespace.
 const (
-	deviceIONamespace     = "http://www.onvif.org/ver10/deviceIO/wsdl"
-	onvifSchemaNamespace  = "http://www.onvif.org/ver10/schema"
+	deviceIONamespace    = "http://www.onvif.org/ver10/deviceIO/wsdl"
+	onvifSchemaNamespace = "http://www.onvif.org/ver10/schema"
 )
 
 // Device IO service errors.

--- a/deviceio.go
+++ b/deviceio.go
@@ -10,7 +10,10 @@ import (
 )
 
 // Device IO service namespace.
-const deviceIONamespace = "http://www.onvif.org/ver10/deviceIO/wsdl"
+const (
+	deviceIONamespace     = "http://www.onvif.org/ver10/deviceIO/wsdl"
+	onvifSchemaNamespace  = "http://www.onvif.org/ver10/schema"
+)
 
 // Device IO service errors.
 var (
@@ -687,7 +690,7 @@ func (c *Client) SendReceiveSerialCommand(ctx context.Context, serialPortToken s
 
 	req := SendReceiveSerialCommand{
 		Xmlns:   deviceIONamespace,
-		XmlnsTT: "http://www.onvif.org/ver10/schema",
+		XmlnsTT: onvifSchemaNamespace,
 		Token:   serialPortToken,
 		SerialData: SerialData{
 			Binary: string(data),
@@ -838,7 +841,7 @@ func (c *Client) SetVideoOutputConfiguration(ctx context.Context, config *VideoO
 
 	req := SetVideoOutputConfiguration{
 		Xmlns:   deviceIONamespace,
-		XmlnsTT: "http://www.onvif.org/ver10/schema",
+		XmlnsTT: onvifSchemaNamespace,
 		Configuration: VideoOutputConfigurationXML{
 			Token:       config.Token,
 			Name:        config.Name,

--- a/deviceio_test.go
+++ b/deviceio_test.go
@@ -9,7 +9,11 @@ import (
 	"testing"
 )
 
-const testDeviceIOXMLHeader = `<?xml version="1.0" encoding="UTF-8"?>`
+const (
+	testDeviceIOXMLHeader    = `<?xml version="1.0" encoding="UTF-8"?>`
+	testVideoOutputToken     = "testVideoOutputToken"
+	testSerialPortToken      = "testSerialPortToken"
+)
 
 func newMockDeviceIOServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -78,7 +82,7 @@ func newMockDeviceIOServer() *httptest.Server {
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
   <SOAP-ENV:Body>
     <tmd:GetVideoOutputsResponse xmlns:tmd="http://www.onvif.org/ver10/deviceIO/wsdl">
-      <tmd:VideoOutputs token="video_out_001">
+      <tmd:VideoOutputs token="testVideoOutputToken">
         <tmd:Layout>
           <tt:Pane xmlns:tt="http://www.onvif.org/ver10/schema" Pane="main">
             <tt:Area bottom="1.0" top="0.0" right="1.0" left="0.0"/>
@@ -100,7 +104,7 @@ func newMockDeviceIOServer() *httptest.Server {
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
   <SOAP-ENV:Body>
     <tmd:GetSerialPortConfigurationOptionsResponse xmlns:tmd="http://www.onvif.org/ver10/deviceIO/wsdl">
-      <tmd:SerialPortConfigurationOptions token="serial_001">
+      <tmd:SerialPortConfigurationOptions token="testSerialPortToken">
         <tmd:BaudRateList><tmd:Items>9600</tmd:Items><tmd:Items>19200</tmd:Items><tmd:Items>38400</tmd:Items></tmd:BaudRateList>
         <tmd:ParityBitList><tmd:Items>None</tmd:Items><tmd:Items>Odd</tmd:Items><tmd:Items>Even</tmd:Items></tmd:ParityBitList>
         <tmd:CharacterLengthList><tmd:Items>7</tmd:Items><tmd:Items>8</tmd:Items></tmd:CharacterLengthList>
@@ -115,7 +119,7 @@ func newMockDeviceIOServer() *httptest.Server {
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
   <SOAP-ENV:Body>
     <tmd:GetSerialPortConfigurationResponse xmlns:tmd="http://www.onvif.org/ver10/deviceIO/wsdl">
-      <tmd:SerialPortConfiguration token="serial_001">
+      <tmd:SerialPortConfiguration token="testSerialPortToken">
         <tmd:Type>RS232</tmd:Type>
         <tmd:BaudRate>9600</tmd:BaudRate>
         <tmd:ParityBit>None</tmd:ParityBit>
@@ -131,7 +135,7 @@ func newMockDeviceIOServer() *httptest.Server {
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
   <SOAP-ENV:Body>
     <tmd:GetSerialPortsResponse xmlns:tmd="http://www.onvif.org/ver10/deviceIO/wsdl">
-      <tmd:SerialPorts token="serial_001">
+      <tmd:SerialPorts token="testSerialPortToken">
         <tmd:Type>RS232</tmd:Type>
       </tmd:SerialPorts>
       <tmd:SerialPorts token="serial_002">
@@ -168,7 +172,7 @@ func newMockDeviceIOServer() *httptest.Server {
     <tmd:GetVideoOutputConfigurationOptionsResponse xmlns:tmd="http://www.onvif.org/ver10/deviceIO/wsdl">
       <tmd:VideoOutputConfigurationOptions>
         <tmd:Name Min="1" Max="64"/>
-        <tmd:OutputTokensAvailable>video_out_001</tmd:OutputTokensAvailable>
+        <tmd:OutputTokensAvailable>testVideoOutputToken</tmd:OutputTokensAvailable>
         <tmd:OutputTokensAvailable>video_out_002</tmd:OutputTokensAvailable>
       </tmd:VideoOutputConfigurationOptions>
     </tmd:GetVideoOutputConfigurationOptionsResponse>
@@ -183,7 +187,7 @@ func newMockDeviceIOServer() *httptest.Server {
       <tmd:VideoOutputConfiguration token="config_001">
         <tmd:Name>Main Output</tmd:Name>
         <tmd:UseCount>2</tmd:UseCount>
-        <tmd:OutputToken>video_out_001</tmd:OutputToken>
+        <tmd:OutputToken>testVideoOutputToken</tmd:OutputToken>
       </tmd:VideoOutputConfiguration>
     </tmd:GetVideoOutputConfigurationResponse>
   </SOAP-ENV:Body>
@@ -416,8 +420,8 @@ func TestGetVideoOutputs(t *testing.T) {
 		t.Fatalf("Expected 1 video output, got %d", len(outputs))
 	}
 
-	if outputs[0].Token != "video_out_001" {
-		t.Errorf("Expected video output token 'video_out_001', got '%s'", outputs[0].Token)
+	if outputs[0].Token != "testVideoOutputToken" {
+		t.Errorf("Expected video output token 'testVideoOutputToken', got '%s'", outputs[0].Token)
 	}
 
 	if outputs[0].Resolution == nil {
@@ -460,8 +464,8 @@ func TestGetSerialPorts(t *testing.T) {
 		t.Fatalf("Expected 2 serial ports, got %d", len(ports))
 	}
 
-	if ports[0].Token != "serial_001" {
-		t.Errorf("Expected first serial port token 'serial_001', got '%s'", ports[0].Token)
+	if ports[0].Token != "testSerialPortToken" {
+		t.Errorf("Expected first serial port token 'testSerialPortToken', got '%s'", ports[0].Token)
 	}
 
 	if ports[0].Type != SerialPortTypeRS232 {
@@ -483,13 +487,13 @@ func TestGetSerialPortConfiguration(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	config, err := client.GetSerialPortConfiguration(ctx, "serial_001")
+	config, err := client.GetSerialPortConfiguration(ctx, "testSerialPortToken")
 	if err != nil {
 		t.Fatalf("GetSerialPortConfiguration failed: %v", err)
 	}
 
-	if config.Token != "serial_001" {
-		t.Errorf("Expected token 'serial_001', got '%s'", config.Token)
+	if config.Token != "testSerialPortToken" {
+		t.Errorf("Expected token 'testSerialPortToken', got '%s'", config.Token)
 	}
 
 	if config.Type != SerialPortTypeRS232 {
@@ -539,7 +543,7 @@ func TestGetSerialPortConfigurationOptions(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	options, err := client.GetSerialPortConfigurationOptions(ctx, "serial_001")
+	options, err := client.GetSerialPortConfigurationOptions(ctx, "testSerialPortToken")
 	if err != nil {
 		t.Fatalf("GetSerialPortConfigurationOptions failed: %v", err)
 	}
@@ -589,7 +593,7 @@ func TestSetSerialPortConfiguration(t *testing.T) {
 	ctx := context.Background()
 
 	config := &SerialPortConfiguration{
-		Token:           "serial_001",
+		Token:           "testSerialPortToken",
 		Type:            SerialPortTypeRS232,
 		BaudRate:        19200,
 		ParityBit:       ParityNone,
@@ -639,7 +643,7 @@ func TestSendReceiveSerialCommand(t *testing.T) {
 
 	ctx := context.Background()
 
-	response, err := client.SendReceiveSerialCommand(ctx, "serial_001", []byte("HELLO"), 5, 10)
+	response, err := client.SendReceiveSerialCommand(ctx, "testSerialPortToken", []byte("HELLO"), 5, 10)
 	if err != nil {
 		t.Fatalf("SendReceiveSerialCommand failed: %v", err)
 	}
@@ -667,7 +671,7 @@ func TestSendReceiveSerialCommandValidation(t *testing.T) {
 	}
 
 	// Test empty data.
-	_, err = client.SendReceiveSerialCommand(ctx, "serial_001", []byte{}, 5, 10)
+	_, err = client.SendReceiveSerialCommand(ctx, "testSerialPortToken", []byte{}, 5, 10)
 	if !errors.Is(err, ErrInvalidSerialData) {
 		t.Errorf("Expected ErrInvalidSerialData, got %v", err)
 	}
@@ -733,7 +737,7 @@ func TestGetVideoOutputConfiguration(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	config, err := client.GetVideoOutputConfiguration(ctx, "video_out_001")
+	config, err := client.GetVideoOutputConfiguration(ctx, "testVideoOutputToken")
 	if err != nil {
 		t.Fatalf("GetVideoOutputConfiguration failed: %v", err)
 	}
@@ -750,8 +754,8 @@ func TestGetVideoOutputConfiguration(t *testing.T) {
 		t.Errorf("Expected use count 2, got %d", config.UseCount)
 	}
 
-	if config.OutputToken != "video_out_001" {
-		t.Errorf("Expected output token 'video_out_001', got '%s'", config.OutputToken)
+	if config.OutputToken != "testVideoOutputToken" {
+		t.Errorf("Expected output token 'testVideoOutputToken', got '%s'", config.OutputToken)
 	}
 }
 
@@ -781,7 +785,7 @@ func TestGetVideoOutputConfigurationOptions(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	options, err := client.GetVideoOutputConfigurationOptions(ctx, "video_out_001")
+	options, err := client.GetVideoOutputConfigurationOptions(ctx, "testVideoOutputToken")
 	if err != nil {
 		t.Fatalf("GetVideoOutputConfigurationOptions failed: %v", err)
 	}
@@ -830,7 +834,7 @@ func TestSetVideoOutputConfiguration(t *testing.T) {
 		Token:            "config_001",
 		Name:             "Main Output",
 		UseCount:         2,
-		OutputToken:      "video_out_001",
+		OutputToken:      "testVideoOutputToken",
 		ForcePersistence: true,
 	}
 

--- a/deviceio_test.go
+++ b/deviceio_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	testDeviceIOXMLHeader    = `<?xml version="1.0" encoding="UTF-8"?>`
-	testVideoOutputToken     = "testVideoOutputToken"
-	testSerialPortToken      = "testSerialPortToken"
+	testDeviceIOXMLHeader = `<?xml version="1.0" encoding="UTF-8"?>`
+	testVideoOutputToken  = "testVideoOutputToken"
+	testSerialPortToken   = "testSerialPortToken"
 )
 
 func newMockDeviceIOServer() *httptest.Server {
@@ -420,7 +420,7 @@ func TestGetVideoOutputs(t *testing.T) {
 		t.Fatalf("Expected 1 video output, got %d", len(outputs))
 	}
 
-	if outputs[0].Token != "testVideoOutputToken" {
+	if outputs[0].Token != testVideoOutputToken {
 		t.Errorf("Expected video output token 'testVideoOutputToken', got '%s'", outputs[0].Token)
 	}
 
@@ -464,7 +464,7 @@ func TestGetSerialPorts(t *testing.T) {
 		t.Fatalf("Expected 2 serial ports, got %d", len(ports))
 	}
 
-	if ports[0].Token != "testSerialPortToken" {
+	if ports[0].Token != testSerialPortToken {
 		t.Errorf("Expected first serial port token 'testSerialPortToken', got '%s'", ports[0].Token)
 	}
 
@@ -487,12 +487,12 @@ func TestGetSerialPortConfiguration(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	config, err := client.GetSerialPortConfiguration(ctx, "testSerialPortToken")
+	config, err := client.GetSerialPortConfiguration(ctx, testSerialPortToken)
 	if err != nil {
 		t.Fatalf("GetSerialPortConfiguration failed: %v", err)
 	}
 
-	if config.Token != "testSerialPortToken" {
+	if config.Token != testSerialPortToken {
 		t.Errorf("Expected token 'testSerialPortToken', got '%s'", config.Token)
 	}
 
@@ -543,7 +543,7 @@ func TestGetSerialPortConfigurationOptions(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	options, err := client.GetSerialPortConfigurationOptions(ctx, "testSerialPortToken")
+	options, err := client.GetSerialPortConfigurationOptions(ctx, testSerialPortToken)
 	if err != nil {
 		t.Fatalf("GetSerialPortConfigurationOptions failed: %v", err)
 	}
@@ -593,7 +593,7 @@ func TestSetSerialPortConfiguration(t *testing.T) {
 	ctx := context.Background()
 
 	config := &SerialPortConfiguration{
-		Token:           "testSerialPortToken",
+		Token:           testSerialPortToken,
 		Type:            SerialPortTypeRS232,
 		BaudRate:        19200,
 		ParityBit:       ParityNone,
@@ -643,7 +643,7 @@ func TestSendReceiveSerialCommand(t *testing.T) {
 
 	ctx := context.Background()
 
-	response, err := client.SendReceiveSerialCommand(ctx, "testSerialPortToken", []byte("HELLO"), 5, 10)
+	response, err := client.SendReceiveSerialCommand(ctx, testSerialPortToken, []byte("HELLO"), 5, 10)
 	if err != nil {
 		t.Fatalf("SendReceiveSerialCommand failed: %v", err)
 	}
@@ -671,7 +671,7 @@ func TestSendReceiveSerialCommandValidation(t *testing.T) {
 	}
 
 	// Test empty data.
-	_, err = client.SendReceiveSerialCommand(ctx, "testSerialPortToken", []byte{}, 5, 10)
+	_, err = client.SendReceiveSerialCommand(ctx, testSerialPortToken, []byte{}, 5, 10)
 	if !errors.Is(err, ErrInvalidSerialData) {
 		t.Errorf("Expected ErrInvalidSerialData, got %v", err)
 	}
@@ -737,7 +737,7 @@ func TestGetVideoOutputConfiguration(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	config, err := client.GetVideoOutputConfiguration(ctx, "testVideoOutputToken")
+	config, err := client.GetVideoOutputConfiguration(ctx, testVideoOutputToken)
 	if err != nil {
 		t.Fatalf("GetVideoOutputConfiguration failed: %v", err)
 	}
@@ -754,7 +754,7 @@ func TestGetVideoOutputConfiguration(t *testing.T) {
 		t.Errorf("Expected use count 2, got %d", config.UseCount)
 	}
 
-	if config.OutputToken != "testVideoOutputToken" {
+	if config.OutputToken != testVideoOutputToken {
 		t.Errorf("Expected output token 'testVideoOutputToken', got '%s'", config.OutputToken)
 	}
 }
@@ -785,7 +785,7 @@ func TestGetVideoOutputConfigurationOptions(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	options, err := client.GetVideoOutputConfigurationOptions(ctx, "testVideoOutputToken")
+	options, err := client.GetVideoOutputConfigurationOptions(ctx, testVideoOutputToken)
 	if err != nil {
 		t.Fatalf("GetVideoOutputConfigurationOptions failed: %v", err)
 	}
@@ -834,7 +834,7 @@ func TestSetVideoOutputConfiguration(t *testing.T) {
 		Token:            "config_001",
 		Name:             "Main Output",
 		UseCount:         2,
-		OutputToken:      "testVideoOutputToken",
+		OutputToken:      testVideoOutputToken,
 		ForcePersistence: true,
 	}
 

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	testCameraNameScope   = "onvif://www.onvif.org/name/TestCamera"
-	testCameraHardware    = "onvif://www.onvif.org/hardware/Model123"
-	testDiscoveryValue    = "value1"
+	testCameraNameScope = "onvif://www.onvif.org/name/TestCamera"
+	testCameraHardware  = "onvif://www.onvif.org/hardware/Model123"
+	testDiscoveryValue  = "value1"
 )
 
 func TestDevice_GetName(t *testing.T) {
@@ -98,7 +98,7 @@ func TestDevice_GetLocation(t *testing.T) {
 			device: &Device{
 				Scopes: []string{
 					"onvif://www.onvif.org/location/Building1",
-					"testCameraHardware",
+					testCameraHardware,
 				},
 			},
 			want: "Building1",
@@ -107,7 +107,7 @@ func TestDevice_GetLocation(t *testing.T) {
 			name: "device without location in scopes",
 			device: &Device{
 				Scopes: []string{
-					"testCameraHardware",
+					testCameraHardware,
 				},
 			},
 			want: "",
@@ -164,8 +164,8 @@ func TestParseSpaceSeparated(t *testing.T) {
 	}{
 		{
 			name:  "multiple values",
-			input: "testDiscoveryValue value2 value3",
-			want:  []string{"testDiscoveryValue", "value2", "value3"},
+			input: testDiscoveryValue + " value2 value3",
+			want:  []string{testDiscoveryValue, "value2", "value3"},
 		},
 		{
 			name:  "empty string",
@@ -174,8 +174,8 @@ func TestParseSpaceSeparated(t *testing.T) {
 		},
 		{
 			name:  "single value",
-			input: "testDiscoveryValue",
-			want:  []string{"testDiscoveryValue"},
+			input: testDiscoveryValue,
+			want:  []string{testDiscoveryValue},
 		},
 	}
 
@@ -205,9 +205,9 @@ func TestDevice_GetTypes(t *testing.T) {
 
 func TestDevice_GetScopes(t *testing.T) {
 	scopes := []string{
-		"testCameraNameScope",
+		testCameraNameScope,
 		"onvif://www.onvif.org/location/Building1",
-		"testCameraHardware",
+		testCameraHardware,
 	}
 
 	device := &Device{
@@ -236,8 +236,8 @@ func TestDevice_GetScopes(t *testing.T) {
 func BenchmarkDeviceGetName(b *testing.B) {
 	device := &Device{
 		Scopes: []string{
-			"testCameraNameScope",
-			"testCameraHardware",
+			testCameraNameScope,
+			testCameraHardware,
 		},
 	}
 

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -8,6 +8,12 @@ import (
 	"time"
 )
 
+const (
+	testCameraNameScope   = "onvif://www.onvif.org/name/TestCamera"
+	testCameraHardware    = "onvif://www.onvif.org/hardware/Model123"
+	testDiscoveryValue    = "value1"
+)
+
 func TestDevice_GetName(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -18,8 +24,8 @@ func TestDevice_GetName(t *testing.T) {
 			name: "device with name in scopes",
 			device: &Device{
 				Scopes: []string{
-					"onvif://www.onvif.org/name/TestCamera",
-					"onvif://www.onvif.org/hardware/Model123",
+					testCameraNameScope,
+					testCameraHardware,
 				},
 			},
 			want: "TestCamera",
@@ -28,7 +34,7 @@ func TestDevice_GetName(t *testing.T) {
 			name: "device without name in scopes",
 			device: &Device{
 				Scopes: []string{
-					"onvif://www.onvif.org/hardware/Model123",
+					testCameraHardware,
 				},
 			},
 			want: "",
@@ -92,7 +98,7 @@ func TestDevice_GetLocation(t *testing.T) {
 			device: &Device{
 				Scopes: []string{
 					"onvif://www.onvif.org/location/Building1",
-					"onvif://www.onvif.org/hardware/Model123",
+					"testCameraHardware",
 				},
 			},
 			want: "Building1",
@@ -101,7 +107,7 @@ func TestDevice_GetLocation(t *testing.T) {
 			name: "device without location in scopes",
 			device: &Device{
 				Scopes: []string{
-					"onvif://www.onvif.org/hardware/Model123",
+					"testCameraHardware",
 				},
 			},
 			want: "",
@@ -158,8 +164,8 @@ func TestParseSpaceSeparated(t *testing.T) {
 	}{
 		{
 			name:  "multiple values",
-			input: "value1 value2 value3",
-			want:  []string{"value1", "value2", "value3"},
+			input: "testDiscoveryValue value2 value3",
+			want:  []string{"testDiscoveryValue", "value2", "value3"},
 		},
 		{
 			name:  "empty string",
@@ -168,8 +174,8 @@ func TestParseSpaceSeparated(t *testing.T) {
 		},
 		{
 			name:  "single value",
-			input: "value1",
-			want:  []string{"value1"},
+			input: "testDiscoveryValue",
+			want:  []string{"testDiscoveryValue"},
 		},
 	}
 
@@ -199,9 +205,9 @@ func TestDevice_GetTypes(t *testing.T) {
 
 func TestDevice_GetScopes(t *testing.T) {
 	scopes := []string{
-		"onvif://www.onvif.org/name/TestCamera",
+		"testCameraNameScope",
 		"onvif://www.onvif.org/location/Building1",
-		"onvif://www.onvif.org/hardware/Model123",
+		"testCameraHardware",
 	}
 
 	device := &Device{
@@ -230,8 +236,8 @@ func TestDevice_GetScopes(t *testing.T) {
 func BenchmarkDeviceGetName(b *testing.B) {
 	device := &Device{
 		Scopes: []string{
-			"onvif://www.onvif.org/name/TestCamera",
-			"onvif://www.onvif.org/hardware/Model123",
+			"testCameraNameScope",
+			"testCameraHardware",
 		},
 	}
 

--- a/event.go
+++ b/event.go
@@ -13,8 +13,8 @@ import (
 
 // Event service namespace.
 const (
-	eventNamespace                  = "http://www.onvif.org/ver10/events/wsdl"
-	oasisEventNamespace             = "http://docs.oasis-open.org/wsn/b-2"
+	eventNamespace      = "http://www.onvif.org/ver10/events/wsdl"
+	oasisEventNamespace = "http://docs.oasis-open.org/wsn/b-2"
 )
 
 // Event service errors.

--- a/event.go
+++ b/event.go
@@ -12,7 +12,10 @@ import (
 )
 
 // Event service namespace.
-const eventNamespace = "http://www.onvif.org/ver10/events/wsdl"
+const (
+	eventNamespace                  = "http://www.onvif.org/ver10/events/wsdl"
+	oasisEventNamespace             = "http://docs.oasis-open.org/wsn/b-2"
+)
 
 // Event service errors.
 var (
@@ -216,7 +219,7 @@ func (c *Client) CreatePullPointSubscription(
 
 	req := CreatePullPointSubscription{
 		XmlnsTev:  eventNamespace,
-		XmlnsWsnt: "http://docs.oasis-open.org/wsn/b-2",
+		XmlnsWsnt: oasisEventNamespace,
 	}
 
 	if filter != "" {

--- a/event_test.go
+++ b/event_test.go
@@ -10,7 +10,10 @@ import (
 	"time"
 )
 
-const testEventXMLHeader = `<?xml version="1.0" encoding="UTF-8"?>`
+const (
+	testEventXMLHeader = `<?xml version="1.0" encoding="UTF-8"?>`
+	testEventBroker    = "mqtt"
+)
 
 func newMockEventServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -698,7 +701,7 @@ func TestSplitSpaceSeparated(t *testing.T) {
 		expected []string
 	}{
 		{"", nil},
-		{"mqtt", []string{"mqtt"}},
+		{testEventBroker, []string{testEventBroker}},
 		{"mqtt mqtts", []string{"mqtt", "mqtts"}},
 		{"  mqtt   mqtts  ", []string{"mqtt", "mqtts"}},
 		{"a b c", []string{"a", "b", "c"}},

--- a/examples/onvif-server/main.go
+++ b/examples/onvif-server/main.go
@@ -12,6 +12,10 @@ import (
 	"github.com/0x524a/onvif-go/server"
 )
 
+const (
+	exampleH264 = "H264"
+)
+
 func main() {
 	// Create a custom multi-lens camera configuration
 	config := &server.Config{
@@ -44,7 +48,7 @@ func main() {
 					Bounds:     server.Bounds{X: 0, Y: 0, Width: 3840, Height: 2160},
 				},
 				VideoEncoder: server.VideoEncoderConfig{
-					Encoding:   "H264",
+					Encoding:   exampleH264,
 					Resolution: server.Resolution{Width: 3840, Height: 2160},
 					Quality:    90,
 					Framerate:  30,
@@ -85,7 +89,7 @@ func main() {
 					Bounds:     server.Bounds{X: 0, Y: 0, Width: 2560, Height: 1440},
 				},
 				VideoEncoder: server.VideoEncoderConfig{
-					Encoding:   "H264",
+					Encoding:   exampleH264,
 					Resolution: server.Resolution{Width: 2560, Height: 1440},
 					Quality:    85,
 					Framerate:  30,
@@ -110,7 +114,7 @@ func main() {
 					Bounds:     server.Bounds{X: 0, Y: 0, Width: 1920, Height: 1080},
 				},
 				VideoEncoder: server.VideoEncoderConfig{
-					Encoding:   "H264",
+					Encoding:   exampleH264,
 					Resolution: server.Resolution{Width: 1920, Height: 1080},
 					Quality:    88,
 					Framerate:  60,
@@ -151,7 +155,7 @@ func main() {
 					Bounds:     server.Bounds{X: 0, Y: 0, Width: 1920, Height: 1080},
 				},
 				VideoEncoder: server.VideoEncoderConfig{
-					Encoding:   "H264",
+					Encoding:   exampleH264,
 					Resolution: server.Resolution{Width: 1920, Height: 1080},
 					Quality:    85,
 					Framerate:  30,

--- a/internal/soap/soap_test.go
+++ b/internal/soap/soap_test.go
@@ -8,6 +8,12 @@ import (
 	"time"
 )
 
+const (
+	testSoapUsername = "admin"
+	testSoapPassword = "password"
+	testSoapValue    = "test"
+)
+
 func TestNewClient(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -16,7 +22,7 @@ func TestNewClient(t *testing.T) {
 	}{
 		{
 			name:     "with credentials",
-			username: "admin",
+			username: testSoapUsername,
 			password: "password123",
 		},
 		{
@@ -64,14 +70,14 @@ func TestBuildEnvelope(t *testing.T) {
 	}{
 		{
 			name:     "with authentication",
-			body:     &testRequest{Value: "test"},
-			username: "admin",
-			password: "password",
+			body:     &testRequest{Value: testSoapValue},
+			username: testSoapUsername,
+			password: testSoapPassword,
 			wantErr:  false,
 		},
 		{
 			name:     "without authentication",
-			body:     &testRequest{Value: "test"},
+			body:     &testRequest{Value: testSoapValue},
 			username: "",
 			password: "",
 			wantErr:  false,
@@ -144,7 +150,7 @@ func TestClientCall(t *testing.T) {
 					w.WriteHeader(http.StatusUnauthorized)
 				}))
 			},
-			username: "admin",
+			username: testSoapUsername,
 			password: "wrong",
 			wantErr:  true,
 		},
@@ -158,8 +164,8 @@ func TestClientCall(t *testing.T) {
 					_, _ = w.Write([]byte("Internal Server Error"))
 				}))
 			},
-			username: "admin",
-			password: "password",
+			username: testSoapUsername,
+			password: testSoapPassword,
 			wantErr:  true,
 		},
 	}
@@ -180,7 +186,7 @@ func TestClientCall(t *testing.T) {
 				Value string `xml:"Value"`
 			}
 
-			req := &testRequest{Value: "test"}
+			req := &testRequest{Value: testSoapValue}
 			var resp testResponse
 
 			ctx := context.Background()
@@ -208,7 +214,7 @@ func TestClientCallWithTimeout(t *testing.T) {
 		Value string `xml:"Value"`
 	}
 
-	req := &testRequest{Value: "test"}
+	req := &testRequest{Value: testSoapValue}
 	var resp interface{}
 
 	// Context with very short timeout
@@ -272,7 +278,7 @@ func BenchmarkBuildEnvelope(b *testing.B) {
 	type testRequest struct {
 		Value string `xml:"Value"`
 	}
-	req := &testRequest{Value: "test"}
+	req := &testRequest{Value: testSoapValue}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/media.go
+++ b/media.go
@@ -11,6 +11,8 @@ import (
 // Media service namespace.
 const mediaNamespace = "http://www.onvif.org/ver10/media/wsdl"
 
+// onvifSchemaNamespace is already defined in deviceio.go and available here
+
 // getMediaEndpoint returns the media endpoint, falling back to the default endpoint if not set.
 func (c *Client) getMediaEndpoint() string {
 	if c.mediaEndpoint != "" {
@@ -177,7 +179,7 @@ func (c *Client) GetStreamURI(ctx context.Context, profileToken string) (*MediaU
 
 	req := GetStreamURI{
 		Xmlns:        mediaNamespace,
-		Xmlnst:       "http://www.onvif.org/ver10/schema",
+		Xmlnst:       onvifSchemaNamespace,
 		ProfileToken: profileToken,
 	}
 	req.StreamSetup.Stream = "RTP-Unicast"

--- a/media.go
+++ b/media.go
@@ -544,7 +544,7 @@ func (c *Client) SetVideoEncoderConfiguration(
 
 	req := SetVideoEncoderConfiguration{
 		Xmlns:            mediaNamespace,
-		Xmlnst:           "http://www.onvif.org/ver10/schema",
+		Xmlnst:           onvifSchemaNamespace,
 		ForcePersistence: forcePersistence,
 	}
 
@@ -906,7 +906,7 @@ func (c *Client) SetAudioEncoderConfiguration(
 
 	req := SetAudioEncoderConfiguration{
 		Xmlns:            mediaNamespace,
-		Xmlnst:           "http://www.onvif.org/ver10/schema",
+		Xmlnst:           onvifSchemaNamespace,
 		ForcePersistence: forcePersistence,
 	}
 
@@ -1087,7 +1087,7 @@ func (c *Client) SetMetadataConfiguration(
 
 	req := SetMetadataConfiguration{
 		Xmlns:            mediaNamespace,
-		Xmlnst:           "http://www.onvif.org/ver10/schema",
+		Xmlnst:           onvifSchemaNamespace,
 		ForcePersistence: forcePersistence,
 	}
 
@@ -1345,7 +1345,7 @@ func (c *Client) SetOSD(ctx context.Context, osd *OSDConfiguration) error {
 
 	req := SetOSD{
 		Xmlns:  mediaNamespace,
-		Xmlnst: "http://www.onvif.org/ver10/schema",
+		Xmlnst: onvifSchemaNamespace,
 	}
 	req.OSD.Token = osd.Token
 
@@ -1386,7 +1386,7 @@ func (c *Client) CreateOSD(
 
 	req := CreateOSD{
 		Xmlns:                         mediaNamespace,
-		Xmlnst:                        "http://www.onvif.org/ver10/schema",
+		Xmlnst:                        onvifSchemaNamespace,
 		VideoSourceConfigurationToken: videoSourceConfigurationToken,
 	}
 	if osd != nil && osd.Token != "" {
@@ -1536,7 +1536,7 @@ func (c *Client) SetProfile(ctx context.Context, profile *Profile) error {
 
 	req := SetProfile{
 		Xmlns:  mediaNamespace,
-		Xmlnst: "http://www.onvif.org/ver10/schema",
+		Xmlnst: onvifSchemaNamespace,
 	}
 	req.Profile.Token = profile.Token
 	req.Profile.Name = profile.Name
@@ -2028,7 +2028,7 @@ func (c *Client) SetAudioOutputConfiguration(ctx context.Context, config *AudioO
 
 	req := SetAudioOutputConfiguration{
 		Xmlns:            mediaNamespace,
-		Xmlnst:           "http://www.onvif.org/ver10/schema",
+		Xmlnst:           onvifSchemaNamespace,
 		ForcePersistence: forcePersistence,
 	}
 
@@ -2776,7 +2776,7 @@ func (c *Client) SetVideoSourceConfiguration(
 
 	req := SetVideoSourceConfiguration{
 		Xmlns:            mediaNamespace,
-		Xmlnst:           "http://www.onvif.org/ver10/schema",
+		Xmlnst:           onvifSchemaNamespace,
 		ForcePersistence: forcePersistence,
 	}
 
@@ -2828,7 +2828,7 @@ func (c *Client) SetAudioSourceConfiguration(ctx context.Context, config *AudioS
 
 	req := SetAudioSourceConfiguration{
 		Xmlns:            mediaNamespace,
-		Xmlnst:           "http://www.onvif.org/ver10/schema",
+		Xmlnst:           onvifSchemaNamespace,
 		ForcePersistence: forcePersistence,
 	}
 
@@ -3471,7 +3471,7 @@ func (c *Client) SetAudioDecoderConfiguration(ctx context.Context, config *Audio
 
 	req := SetAudioDecoderConfiguration{
 		Xmlns:            mediaNamespace,
-		Xmlnst:           "http://www.onvif.org/ver10/schema",
+		Xmlnst:           onvifSchemaNamespace,
 		ForcePersistence: forcePersistence,
 	}
 
@@ -3638,7 +3638,7 @@ func (c *Client) SetVideoAnalyticsConfiguration(ctx context.Context, config *Vid
 
 	req := SetVideoAnalyticsConfiguration{
 		Xmlns:            mediaNamespace,
-		Xmlnst:           "http://www.onvif.org/ver10/schema",
+		Xmlnst:           onvifSchemaNamespace,
 		ForcePersistence: forcePersistence,
 	}
 

--- a/media_test.go
+++ b/media_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 )
 
+const (
+	testProfileToken = "Profile1"
+)
+
 // TestGetProfiles tests GetProfiles operation.
 func TestGetProfiles(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -50,8 +54,8 @@ func TestGetProfiles(t *testing.T) {
 		t.Errorf("Expected 1 profile, got %d", len(profiles))
 	}
 
-	if profiles[0].Token != "Profile1" {
-		t.Errorf("Expected token Profile1, got %s", profiles[0].Token)
+	if profiles[0].Token != testProfileToken {
+		t.Errorf("Expected token %s, got %s", testProfileToken, profiles[0].Token)
 	}
 
 	if profiles[0].Name != "Main Profile" {

--- a/server/imaging.go
+++ b/server/imaging.go
@@ -356,7 +356,7 @@ func (s *Server) HandleGetOptions(body interface{}) (interface{}, error) {
 		Sharpness:        &FloatRange{Min: 0, Max: maxImagingValue},
 		IrCutFilterModes: []string{"ON", offMode, autoMode},
 		BacklightCompensation: &BacklightCompensationOptions{
-			Mode:  []string{"OFF", "ON"},
+			Mode:  []string{offMode, "ON"},
 			Level: &FloatRange{Min: 0, Max: maxImagingValue},
 		},
 		Exposure: &ExposureOptions{
@@ -370,17 +370,17 @@ func (s *Server) HandleGetOptions(body interface{}) (interface{}, error) {
 			Gain:            &FloatRange{Min: 0, Max: maxImagingValue},
 		},
 		Focus: &FocusOptions{
-			AutoFocusModes: []string{"AUTO", "MANUAL"},
+			AutoFocusModes: []string{autoMode, manualMode},
 			DefaultSpeed:   &FloatRange{Min: 0, Max: 1},
 			NearLimit:      &FloatRange{Min: 0, Max: 1},
 			FarLimit:       &FloatRange{Min: 0, Max: 1},
 		},
 		WideDynamicRange: &WideDynamicRangeOptions{
-			Mode:  []string{"OFF", "ON"},
+			Mode:  []string{offMode, "ON"},
 			Level: &FloatRange{Min: 0, Max: 100}, //nolint:mnd // Imaging parameter range
 		},
 		WhiteBalance: &WhiteBalanceOptions{
-			Mode:   []string{"AUTO", "MANUAL"},
+			Mode:   []string{autoMode, manualMode},
 			YrGain: &FloatRange{Min: 0, Max: 255}, //nolint:mnd // White balance gain range
 			YbGain: &FloatRange{Min: 0, Max: 255}, //nolint:mnd // White balance gain range
 		},

--- a/server/imaging.go
+++ b/server/imaging.go
@@ -354,13 +354,13 @@ func (s *Server) HandleGetOptions(body interface{}) (interface{}, error) {
 		ColorSaturation:  &FloatRange{Min: 0, Max: maxImagingValue},
 		Contrast:         &FloatRange{Min: 0, Max: maxImagingValue},
 		Sharpness:        &FloatRange{Min: 0, Max: maxImagingValue},
-		IrCutFilterModes: []string{"ON", "OFF", "AUTO"},
+		IrCutFilterModes: []string{"ON", offMode, autoMode},
 		BacklightCompensation: &BacklightCompensationOptions{
 			Mode:  []string{"OFF", "ON"},
 			Level: &FloatRange{Min: 0, Max: maxImagingValue},
 		},
 		Exposure: &ExposureOptions{
-			Mode:            []string{"AUTO", "MANUAL"},
+			Mode:            []string{autoMode, manualMode},
 			Priority:        []string{"LowNoise", "FrameRate"},
 			MinExposureTime: &FloatRange{Min: 1, Max: maxExposureTime},
 			MaxExposureTime: &FloatRange{Min: 1, Max: maxExposureTime},

--- a/server/imaging_test.go
+++ b/server/imaging_test.go
@@ -6,8 +6,13 @@ import (
 )
 
 const (
-	exposureModeAuto   = "AUTO"
-	exposureModeManual = "MANUAL"
+	exposureModeAuto    = "AUTO"
+	exposureModeManual  = "MANUAL"
+	backlightCompOFF    = "OFF"
+	backlightCompOn     = "ON"
+	backlightCompAuto   = "AUTO"
+	backlightCompInvExp = "Invalid mode"
+	backlightCompInvVal = "INVALID"
 )
 
 func TestHandleGetImagingSettings(t *testing.T) {
@@ -238,12 +243,12 @@ func TestBacklightCompensation(t *testing.T) {
 		},
 		{
 			name:        "Backlight OFF",
-			comp:        BacklightCompensation{Mode: "OFF", Level: 0},
+			comp:        BacklightCompensation{Mode: backlightCompOFF, Level: 0},
 			expectValid: true,
 		},
 		{
-			name:        "Invalid mode",
-			comp:        BacklightCompensation{Mode: "INVALID", Level: 50},
+			name:        backlightCompInvExp,
+			comp:        BacklightCompensation{Mode: backlightCompInvVal, Level: 50},
 			expectValid: false,
 		},
 		{
@@ -418,7 +423,7 @@ func TestWideDynamicRange(t *testing.T) {
 			expectValid: true,
 		},
 		{
-			name:        "Invalid mode",
+			name:        backlightCompInvExp,
 			wdr:         WDRSettings{Mode: "INVALID", Level: 50},
 			expectValid: false,
 		},

--- a/server/imaging_test.go
+++ b/server/imaging_test.go
@@ -260,7 +260,7 @@ func TestBacklightCompensation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			valid := (tt.comp.Mode == "ON" || tt.comp.Mode == "OFF") &&
+			valid := (tt.comp.Mode == backlightCompOn || tt.comp.Mode == offMode) &&
 				tt.comp.Level >= 0 && tt.comp.Level <= 100
 			if valid != tt.expectValid {
 				t.Errorf("Backlight validation failed: Mode=%s, Level=%f", tt.comp.Mode, tt.comp.Level)
@@ -298,7 +298,7 @@ func TestExposureSettings(t *testing.T) {
 		{
 			name: "Invalid mode",
 			exposure: ExposureSettings{
-				Mode: "INVALID",
+				Mode: invalidModeValue,
 			},
 			expectValid: false,
 		},

--- a/server/media.go
+++ b/server/media.go
@@ -207,12 +207,12 @@ func (s *Server) HandleGetProfiles(body interface{}) (interface{}, error) {
 					EncodingInterval: 1,
 					BitrateLimit:     profileCfg.VideoEncoder.Bitrate,
 				},
-				SessionTimeout: "PT60S",
+				SessionTimeout: sessionTimeout,
 			},
 		}
 
 		// Add H264 configuration if encoding is H264
-		if profileCfg.VideoEncoder.Encoding == "H264" {
+		if profileCfg.VideoEncoder.Encoding == h264 {
 			profile.VideoEncoderConfiguration.H264 = &H264Configuration{
 				GovLength:   profileCfg.VideoEncoder.GovLength,
 				H264Profile: "Main",
@@ -237,7 +237,7 @@ func (s *Server) HandleGetProfiles(body interface{}) (interface{}, error) {
 				Encoding:       profileCfg.AudioEncoder.Encoding,
 				Bitrate:        profileCfg.AudioEncoder.Bitrate,
 				SampleRate:     profileCfg.AudioEncoder.SampleRate,
-				SessionTimeout: "PT60S",
+				SessionTimeout: sessionTimeout,
 			}
 		}
 

--- a/server/media_test.go
+++ b/server/media_test.go
@@ -5,6 +5,16 @@ import (
 	"testing"
 )
 
+// Shared test literals reused across media_test.go, server_test.go, and
+// types_test.go in this package.
+const (
+	testProfileName1   = "Profile 1"
+	testVideoSourceTok = "vs_1"
+	testZeroWidthName  = "Zero width"
+	testInvalidToken   = "invalid-token"
+	testPTZNodeToken   = "ptz_node"
+)
+
 func TestHandleGetProfiles(t *testing.T) {
 	config := createTestConfig()
 	server, _ := New(config)
@@ -130,12 +140,12 @@ func TestHandleGetVideoSources(t *testing.T) {
 
 func TestMediaProfileStructure(t *testing.T) {
 	profile := MediaProfile{
-		Token: "profile_1",
+		Token: defaultProfileToken,
 		Fixed: true,
-		Name:  "Profile 1",
+		Name:  testProfileName1,
 		VideoSourceConfiguration: &VideoSourceConfiguration{
-			Token:       "vs_1",
-			SourceToken: "vs_1",
+			Token:       testVideoSourceTok,
+			SourceToken: testVideoSourceTok,
 			Bounds: IntRectangle{
 				X:      0,
 				Y:      0,
@@ -200,8 +210,8 @@ func TestGetProfilesResponseXML(t *testing.T) {
 	resp := &GetProfilesResponse{
 		Profiles: []MediaProfile{
 			{
-				Token: "profile_1",
-				Name:  "Profile 1",
+				Token: defaultProfileToken,
+				Name:  testProfileName1,
 			},
 		},
 	}
@@ -220,7 +230,7 @@ func TestGetProfilesResponseXML(t *testing.T) {
 	if !contains(xmlStr, "Profiles") {
 		t.Error("Profiles element not in XML")
 	}
-	if !contains(xmlStr, "profile_1") {
+	if !contains(xmlStr, defaultProfileToken) {
 		t.Error("Profile token not in XML")
 	}
 }
@@ -237,7 +247,7 @@ func TestIntRectangle(t *testing.T) {
 			expectValid: true,
 		},
 		{
-			name:        "Zero width",
+			name:        testZeroWidthName,
 			rect:        IntRectangle{X: 0, Y: 0, Width: 0, Height: 100},
 			expectValid: false,
 		},
@@ -290,7 +300,7 @@ func TestVideoResolution(t *testing.T) {
 			expectValid: true,
 		},
 		{
-			name:        "Zero width",
+			name:        testZeroWidthName,
 			resolution:  VideoResolution{Width: 0, Height: 1080},
 			expectValid: false,
 		},

--- a/server/media_test.go
+++ b/server/media_test.go
@@ -145,7 +145,7 @@ func TestMediaProfileStructure(t *testing.T) {
 		},
 		VideoEncoderConfiguration: &VideoEncoderConfiguration{
 			Token:    "ve_1",
-			Encoding: "H264",
+			Encoding: h264,
 			Resolution: VideoResolution{
 				Width:  1920,
 				Height: 1080,

--- a/server/server.go
+++ b/server/server.go
@@ -84,7 +84,7 @@ func New(config *Config) (*Server, error) {
 				CurrentPos:    0.5, //nolint:mnd // Focus position
 			},
 			WhiteBalance: WhiteBalanceSettings{
-				Mode:   "AUTO",
+				Mode:   autoMode,
 				CrGain: 128, //nolint:mnd // White balance gain
 				CbGain: 128, //nolint:mnd // White balance gain
 			},

--- a/server/server.go
+++ b/server/server.go
@@ -31,7 +31,7 @@ func New(config *Config) (*Server, error) {
 		streamPath := fmt.Sprintf("/stream%d", i)
 
 		host := config.Host
-		if host == "0.0.0.0" || host == "" {
+		if host == defaultHost || host == "" {
 			host = "localhost"
 		}
 
@@ -61,13 +61,13 @@ func New(config *Config) (*Server, error) {
 			Contrast:    50.0, //nolint:mnd // Default imaging value
 			Saturation:  50.0, //nolint:mnd // Default imaging value
 			Sharpness:   50.0, //nolint:mnd // Default imaging value
-			IrCutFilter: "AUTO",
+			IrCutFilter: autoMode,
 			BacklightComp: BacklightCompensation{
-				Mode:  "OFF",
+				Mode:  offMode,
 				Level: 0,
 			},
 			Exposure: ExposureSettings{
-				Mode:         "AUTO",
+				Mode:         autoMode,
 				Priority:     "FrameRate",
 				MinExposure:  1,
 				MaxExposure:  10000, //nolint:mnd // Exposure time in microseconds
@@ -77,7 +77,7 @@ func New(config *Config) (*Server, error) {
 				Gain:         50,  //nolint:mnd // Gain value
 			},
 			Focus: FocusSettings{
-				AutoFocusMode: "AUTO",
+				AutoFocusMode: autoMode,
 				DefaultSpeed:  0.5, //nolint:mnd // Focus speed
 				NearLimit:     0,
 				FarLimit:      1,
@@ -89,7 +89,7 @@ func New(config *Config) (*Server, error) {
 				CbGain: 128, //nolint:mnd // White balance gain
 			},
 			WideDynamicRange: WDRSettings{
-				Mode:  "OFF",
+				Mode:  offMode,
 				Level: 0,
 			},
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -129,7 +129,7 @@ func TestGetStreamConfig(t *testing.T) {
 		},
 		{
 			name:     "Get non-existent stream",
-			token:    "invalid-token",
+			token:    testInvalidToken,
 			expectOk: false,
 		},
 	}
@@ -170,7 +170,7 @@ func TestUpdateStreamURI(t *testing.T) {
 		},
 		{
 			name:        "Update non-existent stream",
-			token:       "invalid-token",
+			token:       testInvalidToken,
 			newURI:      "rtsp://localhost:8554/stream",
 			expectError: true,
 		},
@@ -231,7 +231,7 @@ func TestGetPTZState(t *testing.T) {
 	if profileWithPTZ == "" {
 		// Create config with PTZ
 		config.Profiles[0].PTZ = &PTZConfig{
-			NodeToken: "ptz_node",
+			NodeToken: testPTZNodeToken,
 			PanRange:  Range{Min: -360, Max: 360},
 			TiltRange: Range{Min: -90, Max: 90},
 			ZoomRange: Range{Min: 0, Max: 10},
@@ -252,7 +252,7 @@ func TestGetPTZState(t *testing.T) {
 		},
 		{
 			name:     "Get PTZ state for non-existent profile",
-			token:    "invalid-token",
+			token:    testInvalidToken,
 			expectOk: false,
 		},
 	}
@@ -301,7 +301,7 @@ func TestGetImagingState(t *testing.T) {
 		},
 		{
 			name:     "Get imaging state for non-existent source",
-			token:    "invalid-token",
+			token:    testInvalidToken,
 			expectOk: false,
 		},
 	}
@@ -380,7 +380,7 @@ func createTestConfig() *Config {
 		Profiles: []ProfileConfig{
 			{
 				Token: "profile_token_1",
-				Name:  "Profile 1",
+				Name:  testProfileName1,
 				VideoSource: VideoSourceConfig{
 					Token:      "video_source_1",
 					Name:       "Video Source 1",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -366,7 +366,7 @@ func createTestConfig() *Config {
 	return &Config{
 		Host:     "127.0.0.1",
 		Port:     8080,
-		BasePath: "/onvif",
+		BasePath: onvifBasePath,
 		Timeout:  30 * time.Second,
 		DeviceInfo: DeviceInfo{
 			Manufacturer:    "Test",
@@ -394,7 +394,7 @@ func createTestConfig() *Config {
 					},
 				},
 				VideoEncoder: VideoEncoderConfig{
-					Encoding:   "H264",
+					Encoding:   h264,
 					Resolution: Resolution{Width: 1920, Height: 1080},
 					Quality:    80,
 					Framerate:  30,

--- a/server/types.go
+++ b/server/types.go
@@ -28,6 +28,15 @@ const (
 	maxZoom           = 3
 	lowPTZSpeed       = 0.3
 	presetZoom        = 2
+	h264              = "H264"
+	autoMode          = "AUTO"
+	manualMode        = "MANUAL"
+	offMode           = "OFF"
+	onvifBasePath     = "/onvif"
+	sessionTimeout    = "PT60S"
+	homePresetName    = "Home"
+	invalidModeError  = "Invalid mode"
+	invalidModeValue  = "INVALID"
 )
 
 // Config represents the ONVIF server configuration.
@@ -255,7 +264,7 @@ type WDRSettings struct {
 //nolint:funlen // DefaultConfig has many statements due to comprehensive default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		Host:     "0.0.0.0",
+		Host:     defaultHost,
 		Port:     defaultPort,
 		BasePath: "/onvif",
 		Timeout:  defaultTimeoutSec * time.Second,
@@ -283,7 +292,7 @@ func DefaultConfig() *Config {
 					Bounds:     Bounds{X: 0, Y: 0, Width: defaultWidth, Height: defaultHeight},
 				},
 				VideoEncoder: VideoEncoderConfig{
-					Encoding:   "H264",
+					Encoding:   h264,
 					Resolution: Resolution{Width: defaultWidth, Height: defaultHeight},
 					Quality:    defaultQuality,
 					Framerate:  defaultFramerate,
@@ -302,7 +311,7 @@ func DefaultConfig() *Config {
 					SupportsAbsolute:   true,
 					SupportsRelative:   true,
 					Presets: []Preset{
-						{Token: "preset_0", Name: "Home", Position: PTZPosition{Pan: 0, Tilt: 0, Zoom: 0}},
+						{Token: "preset_0", Name: homePresetName, Position: PTZPosition{Pan: 0, Tilt: 0, Zoom: 0}},
 						{
 							Token: "preset_1", Name: "Entrance",
 							Position: PTZPosition{Pan: -45, Tilt: -10, Zoom: defaultPTZSpeed},
@@ -326,7 +335,7 @@ func DefaultConfig() *Config {
 					Bounds:     Bounds{X: 0, Y: 0, Width: mediumWidth, Height: mediumHeight},
 				},
 				VideoEncoder: VideoEncoderConfig{
-					Encoding:   "H264",
+					Encoding:   h264,
 					Resolution: Resolution{Width: mediumWidth, Height: mediumHeight},
 					Quality:    mediumQuality,
 					Framerate:  defaultFramerate,
@@ -350,7 +359,7 @@ func DefaultConfig() *Config {
 					Bounds:     Bounds{X: 0, Y: 0, Width: defaultWidth, Height: defaultHeight},
 				},
 				VideoEncoder: VideoEncoderConfig{
-					Encoding:   "H264",
+					Encoding:   h264,
 					Resolution: Resolution{Width: defaultWidth, Height: defaultHeight},
 					Quality:    highQuality,
 					Framerate:  lowFramerate,
@@ -369,7 +378,7 @@ func DefaultConfig() *Config {
 					SupportsAbsolute:   true,
 					SupportsRelative:   true,
 					Presets: []Preset{
-						{Token: "preset_2_0", Name: "Home", Position: PTZPosition{Pan: 0, Tilt: 0, Zoom: 0}},
+						{Token: "preset_2_0", Name: homePresetName, Position: PTZPosition{Pan: 0, Tilt: 0, Zoom: 0}},
 						{
 							Token: "preset_2_1", Name: "Zoom In",
 							Position: PTZPosition{Pan: 0, Tilt: 0, Zoom: presetZoom},

--- a/server/types.go
+++ b/server/types.go
@@ -8,35 +8,41 @@ import (
 )
 
 const (
-	defaultPort       = 8080
-	defaultTimeoutSec = 30
-	defaultWidth      = 1920
-	defaultHeight     = 1080
-	defaultFramerate  = 30
-	defaultQuality    = 80
-	defaultBitrate    = 4096
-	maxPan            = 180
-	maxTilt           = 90
-	defaultPTZSpeed   = 0.5
-	mediumWidth       = 1280
-	mediumHeight      = 720
-	mediumQuality     = 75
-	highQuality       = 85
-	mediumBitrate     = 2048
-	lowFramerate      = 25
-	highBitrate       = 6144
-	maxZoom           = 3
-	lowPTZSpeed       = 0.3
-	presetZoom        = 2
-	h264              = "H264"
-	autoMode          = "AUTO"
-	manualMode        = "MANUAL"
-	offMode           = "OFF"
-	onvifBasePath     = "/onvif"
-	sessionTimeout    = "PT60S"
-	homePresetName    = "Home"
-	invalidModeError  = "Invalid mode"
-	invalidModeValue  = "INVALID"
+	defaultPort         = 8080
+	defaultTimeoutSec   = 30
+	defaultWidth        = 1920
+	defaultHeight       = 1080
+	defaultFramerate    = 30
+	defaultQuality      = 80
+	defaultBitrate      = 4096
+	maxPan              = 180
+	maxTilt             = 90
+	defaultPTZSpeed     = 0.5
+	mediumWidth         = 1280
+	mediumHeight        = 720
+	mediumQuality       = 75
+	highQuality         = 85
+	mediumBitrate       = 2048
+	lowFramerate        = 25
+	highBitrate         = 6144
+	maxZoom             = 3
+	lowPTZSpeed         = 0.3
+	presetZoom          = 2
+	h264                = "H264"
+	autoMode            = "AUTO"
+	manualMode          = "MANUAL"
+	offMode             = "OFF"
+	onvifBasePath       = "/onvif"
+	sessionTimeout      = "PT60S"
+	homePresetName      = "Home"
+	invalidModeError    = "Invalid mode"
+	invalidModeValue    = "INVALID"
+	defaultProfileToken = "profile_1"
+	defaultPresetToken  = "preset_1"
+	deviceServiceKey    = "device"
+	imagingServiceKey   = "imaging"
+	mediaServiceKey     = "media"
+	ptzServiceKey       = "ptz"
 )
 
 // Config represents the ONVIF server configuration.
@@ -313,7 +319,7 @@ func DefaultConfig() *Config {
 					Presets: []Preset{
 						{Token: "preset_0", Name: homePresetName, Position: PTZPosition{Pan: 0, Tilt: 0, Zoom: 0}},
 						{
-							Token: "preset_1", Name: "Entrance",
+							Token: defaultPresetToken, Name: "Entrance",
 							Position: PTZPosition{Pan: -45, Tilt: -10, Zoom: defaultPTZSpeed},
 						},
 					},
@@ -325,7 +331,7 @@ func DefaultConfig() *Config {
 				},
 			},
 			{
-				Token: "profile_1",
+				Token: defaultProfileToken,
 				Name:  "Wide Angle Camera",
 				VideoSource: VideoSourceConfig{
 					Token:      "video_source_1",
@@ -414,13 +420,13 @@ func (c *Config) ServiceEndpoints(host string) map[string]string {
 	}
 
 	endpoints := map[string]string{
-		"device":  baseURL + "/device_service",
-		"media":   baseURL + "/media_service",
-		"imaging": baseURL + "/imaging_service",
+		deviceServiceKey:  baseURL + "/device_service",
+		mediaServiceKey:   baseURL + "/media_service",
+		imagingServiceKey: baseURL + "/imaging_service",
 	}
 
 	if c.SupportPTZ {
-		endpoints["ptz"] = baseURL + "/ptz_service"
+		endpoints[ptzServiceKey] = baseURL + "/ptz_service"
 	}
 
 	if c.SupportEvents {

--- a/server/types_test.go
+++ b/server/types_test.go
@@ -270,7 +270,7 @@ func TestPreset(t *testing.T) {
 			name: "Valid preset",
 			preset: Preset{
 				Token:    "preset_1",
-				Name:     "Home",
+				Name:     homePresetName,
 				Position: PTZPosition{Pan: 0, Tilt: 0, Zoom: 0},
 			},
 			expectValid: true,
@@ -363,7 +363,7 @@ func TestVideoEncoderConfig(t *testing.T) {
 		{
 			name: "Valid H264 encoder",
 			encoderConfig: VideoEncoderConfig{
-				Encoding:   "H264",
+				Encoding:   h264,
 				Resolution: Resolution{Width: 1920, Height: 1080},
 				Quality:    80,
 				Framerate:  30,
@@ -395,7 +395,7 @@ func TestVideoEncoderConfig(t *testing.T) {
 		{
 			name: "Invalid quality (too high)",
 			encoderConfig: VideoEncoderConfig{
-				Encoding:   "H264",
+				Encoding:   h264,
 				Resolution: Resolution{Width: 1920, Height: 1080},
 				Quality:    101,
 				Framerate:  30,
@@ -405,7 +405,7 @@ func TestVideoEncoderConfig(t *testing.T) {
 		{
 			name: "Invalid quality (negative)",
 			encoderConfig: VideoEncoderConfig{
-				Encoding:   "H264",
+				Encoding:   h264,
 				Resolution: Resolution{Width: 1920, Height: 1080},
 				Quality:    -1,
 				Framerate:  30,
@@ -444,7 +444,7 @@ func TestProfileConfig(t *testing.T) {
 					Framerate:  30,
 				},
 				VideoEncoder: VideoEncoderConfig{
-					Encoding:   "H264",
+					Encoding:   h264,
 					Resolution: Resolution{Width: 1920, Height: 1080},
 					Quality:    80,
 					Framerate:  30,
@@ -557,7 +557,7 @@ func TestServiceEndpoints(t *testing.T) {
 			config: &Config{
 				Host:          "192.168.1.100",
 				Port:          8080,
-				BasePath:      "/onvif",
+				BasePath:      onvifBasePath,
 				SupportPTZ:    true,
 				SupportEvents: true,
 			},
@@ -569,7 +569,7 @@ func TestServiceEndpoints(t *testing.T) {
 			config: &Config{
 				Host:          "192.168.1.100",
 				Port:          8080,
-				BasePath:      "/onvif",
+				BasePath:      onvifBasePath,
 				SupportPTZ:    false,
 				SupportEvents: false,
 			},
@@ -656,7 +656,7 @@ func TestToONVIFProfile(t *testing.T) {
 			Resolution: Resolution{Width: 1920, Height: 1080},
 		},
 		VideoEncoder: VideoEncoderConfig{
-			Encoding:   "H264",
+			Encoding:   h264,
 			Bitrate:    4096,
 			Framerate:  30,
 			Resolution: Resolution{Width: 1920, Height: 1080},

--- a/server/types_test.go
+++ b/server/types_test.go
@@ -156,7 +156,7 @@ func TestResolution(t *testing.T) {
 			expectValid: true,
 		},
 		{
-			name:        "Zero width",
+			name:        testZeroWidthName,
 			resolution:  Resolution{Width: 0, Height: 1080},
 			expectValid: false,
 		},
@@ -239,7 +239,7 @@ func TestBounds(t *testing.T) {
 			expectValid: true,
 		},
 		{
-			name:        "Zero width",
+			name:        testZeroWidthName,
 			bounds:      Bounds{X: 0, Y: 0, Width: 0, Height: 1080},
 			expectValid: false,
 		},
@@ -269,7 +269,7 @@ func TestPreset(t *testing.T) {
 		{
 			name: "Valid preset",
 			preset: Preset{
-				Token:    "preset_1",
+				Token:    defaultPresetToken,
 				Name:     homePresetName,
 				Position: PTZPosition{Pan: 0, Tilt: 0, Zoom: 0},
 			},
@@ -286,7 +286,7 @@ func TestPreset(t *testing.T) {
 		{
 			name: "Preset with empty name",
 			preset: Preset{
-				Token: "preset_1",
+				Token: defaultPresetToken,
 				Name:  "",
 			},
 			expectValid: false,
@@ -313,7 +313,7 @@ func TestPTZConfig(t *testing.T) {
 		{
 			name: "Valid PTZ config",
 			ptzConfig: &PTZConfig{
-				NodeToken: "ptz_node",
+				NodeToken: testPTZNodeToken,
 				PanRange:  Range{Min: -360, Max: 360},
 				TiltRange: Range{Min: -90, Max: 90},
 				ZoomRange: Range{Min: 0, Max: 10},
@@ -323,12 +323,12 @@ func TestPTZConfig(t *testing.T) {
 		{
 			name: "PTZ config with presets",
 			ptzConfig: &PTZConfig{
-				NodeToken: "ptz_node",
+				NodeToken: testPTZNodeToken,
 				PanRange:  Range{Min: -360, Max: 360},
 				TiltRange: Range{Min: -90, Max: 90},
 				ZoomRange: Range{Min: 0, Max: 10},
 				Presets: []Preset{
-					{Token: "preset_1", Name: "Home"},
+					{Token: defaultPresetToken, Name: "Home"},
 					{Token: "preset_2", Name: "Away"},
 				},
 			},
@@ -435,10 +435,10 @@ func TestProfileConfig(t *testing.T) {
 		{
 			name: "Valid profile config",
 			profileConfig: ProfileConfig{
-				Token: "profile_1",
-				Name:  "Profile 1",
+				Token: defaultProfileToken,
+				Name:  testProfileName1,
 				VideoSource: VideoSourceConfig{
-					Token:      "vs_1",
+					Token:      testVideoSourceTok,
 					Name:       "Video Source",
 					Resolution: Resolution{Width: 1920, Height: 1080},
 					Framerate:  30,
@@ -463,7 +463,7 @@ func TestProfileConfig(t *testing.T) {
 		{
 			name: "Profile with empty name",
 			profileConfig: ProfileConfig{
-				Token: "profile_1",
+				Token: defaultProfileToken,
 				Name:  "",
 			},
 			expectValid: false,
@@ -562,7 +562,7 @@ func TestServiceEndpoints(t *testing.T) {
 				SupportEvents: true,
 			},
 			host:           "",
-			expectServices: []string{"device", "media", "imaging", "ptz", "events"},
+			expectServices: []string{deviceServiceKey, mediaServiceKey, imagingServiceKey, ptzServiceKey, "events"},
 		},
 		{
 			name: "Custom host",
@@ -574,38 +574,38 @@ func TestServiceEndpoints(t *testing.T) {
 				SupportEvents: false,
 			},
 			host:           "custom.example.com",
-			expectServices: []string{"device", "media", "imaging"},
+			expectServices: []string{deviceServiceKey, mediaServiceKey, imagingServiceKey},
 		},
 		{
 			name: "Port 80",
 			config: &Config{
 				Host:       "localhost",
 				Port:       80,
-				BasePath:   "/onvif",
+				BasePath:   onvifBasePath,
 				SupportPTZ: true,
 			},
 			host:           "",
-			expectServices: []string{"device", "media", "imaging", "ptz"},
+			expectServices: []string{deviceServiceKey, mediaServiceKey, imagingServiceKey, ptzServiceKey},
 		},
 		{
 			name: "Default host with 0.0.0.0",
 			config: &Config{
 				Host:     "0.0.0.0",
 				Port:     8080,
-				BasePath: "/onvif",
+				BasePath: onvifBasePath,
 			},
 			host:           "",
-			expectServices: []string{"device", "media", "imaging"},
+			expectServices: []string{deviceServiceKey, mediaServiceKey, imagingServiceKey},
 		},
 		{
 			name: "Empty host fallback",
 			config: &Config{
 				Host:     "",
 				Port:     8080,
-				BasePath: "/onvif",
+				BasePath: onvifBasePath,
 			},
 			host:           "",
-			expectServices: []string{"device", "media", "imaging"},
+			expectServices: []string{deviceServiceKey, mediaServiceKey, imagingServiceKey},
 		},
 	}
 
@@ -641,14 +641,14 @@ func TestServiceEndpointsURL(t *testing.T) {
 	endpoints := config.ServiceEndpoints("example.com")
 
 	expectedDeviceURL := "http://example.com:9000/services/device_service"
-	if endpoints["device"] != expectedDeviceURL {
-		t.Errorf("Device endpoint mismatch: got %s, want %s", endpoints["device"], expectedDeviceURL)
+	if endpoints[deviceServiceKey] != expectedDeviceURL {
+		t.Errorf("Device endpoint mismatch: got %s, want %s", endpoints[deviceServiceKey], expectedDeviceURL)
 	}
 }
 
 func TestToONVIFProfile(t *testing.T) {
 	profile := &ProfileConfig{
-		Token: "profile_1",
+		Token: defaultProfileToken,
 		Name:  "HD Profile",
 		VideoSource: VideoSourceConfig{
 			Token:      "source_1",
@@ -670,7 +670,7 @@ func TestToONVIFProfile(t *testing.T) {
 
 	onvifProfile := profile.ToONVIFProfile()
 
-	if onvifProfile.Token != "profile_1" {
+	if onvifProfile.Token != defaultProfileToken {
 		t.Errorf("Profile token mismatch: got %s", onvifProfile.Token)
 	}
 	if onvifProfile.Name != "HD Profile" {

--- a/testing/capture_types.go
+++ b/testing/capture_types.go
@@ -103,6 +103,7 @@ func (e *CapturedExchangeV2) GetProfileToken() string {
 	if token, ok := e.Parameters["ProfileToken"].(string); ok {
 		return token
 	}
+
 	return ""
 }
 
@@ -118,6 +119,7 @@ func (e *CapturedExchangeV2) GetConfigurationToken() string {
 	if token, ok := e.Parameters["Token"].(string); ok {
 		return token
 	}
+
 	return ""
 }
 
@@ -129,6 +131,7 @@ func (e *CapturedExchangeV2) GetVideoSourceToken() string {
 	if token, ok := e.Parameters["VideoSourceToken"].(string); ok {
 		return token
 	}
+
 	return ""
 }
 
@@ -140,6 +143,7 @@ func (e *CapturedExchangeV2) GetAudioSourceToken() string {
 	if token, ok := e.Parameters["AudioSourceToken"].(string); ok {
 		return token
 	}
+
 	return ""
 }
 
@@ -151,6 +155,7 @@ func (e *CapturedExchangeV2) GetPresetToken() string {
 	if token, ok := e.Parameters["PresetToken"].(string); ok {
 		return token
 	}
+
 	return ""
 }
 
@@ -162,6 +167,7 @@ func (e *CapturedExchangeV2) GetNodeToken() string {
 	if token, ok := e.Parameters["NodeToken"].(string); ok {
 		return token
 	}
+
 	return ""
 }
 
@@ -173,6 +179,7 @@ func (e *CapturedExchangeV2) GetOSDToken() string {
 	if token, ok := e.Parameters["OSDToken"].(string); ok {
 		return token
 	}
+
 	return ""
 }
 
@@ -219,6 +226,7 @@ func (k MatchKey) String() string {
 	if k.OSDToken != "" {
 		s += "[OSD:" + k.OSDToken + "]"
 	}
+
 	return s
 }
 
@@ -280,6 +288,7 @@ func addTokenScore(score int, token1, token2 string) int {
 	if token1 != "" && token1 == token2 {
 		return score + tokenScoreBonus
 	}
+
 	return score
 }
 
@@ -310,11 +319,12 @@ func DetectCaptureVersion(data []byte) string {
 		Version string `json:"version"`
 	}
 	if err := json.Unmarshal(data, &probe); err != nil {
-		return "1.0"
+		return RegistryVersion
 	}
 	if probe.Version == "" {
-		return "1.0"
+		return RegistryVersion
 	}
+
 	return probe.Version
 }
 
@@ -354,6 +364,7 @@ func DetermineServiceType(soapBody string) ServiceType {
 			return svc
 		}
 	}
+
 	return ServiceUnknown
 }
 
@@ -369,5 +380,6 @@ func findString(s, substr string) int {
 			return i
 		}
 	}
+
 	return -1
 }

--- a/testing/capture_types_test.go
+++ b/testing/capture_types_test.go
@@ -5,6 +5,11 @@ import (
 	"testing"
 )
 
+const (
+	testCaptureProfileToken = "profile1"
+	testCaptureConfigToken  = "config1"
+)
+
 func TestDetectCaptureVersion(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -14,7 +19,7 @@ func TestDetectCaptureVersion(t *testing.T) {
 		{
 			name:     "V1 format (no version)",
 			input:    `{"timestamp":"2025-01-01T00:00:00Z","operation":1}`,
-			expected: "1.0",
+			expected: RegistryVersion,
 		},
 		{
 			name:     "V2 format",
@@ -24,12 +29,12 @@ func TestDetectCaptureVersion(t *testing.T) {
 		{
 			name:     "Empty object",
 			input:    `{}`,
-			expected: "1.0",
+			expected: RegistryVersion,
 		},
 		{
 			name:     "Invalid JSON",
 			input:    `{invalid}`,
-			expected: "1.0",
+			expected: RegistryVersion,
 		},
 	}
 
@@ -73,18 +78,18 @@ func TestCapturedExchangeV2_IsV2(t *testing.T) {
 func TestCapturedExchangeV2_GetTokens(t *testing.T) {
 	exchange := CapturedExchangeV2{
 		Parameters: map[string]interface{}{
-			"ProfileToken":       "profile1",
-			"ConfigurationToken": "config1",
+			"ProfileToken":       testCaptureProfileToken,
+			"ConfigurationToken": testCaptureConfigToken,
 			"VideoSourceToken":   "video1",
 		},
 	}
 
-	if token := exchange.GetProfileToken(); token != "profile1" {
-		t.Errorf("GetProfileToken() = %v, want %v", token, "profile1")
+	if token := exchange.GetProfileToken(); token != testCaptureProfileToken {
+		t.Errorf("GetProfileToken() = %v, want %v", token, testCaptureProfileToken)
 	}
 
-	if token := exchange.GetConfigurationToken(); token != "config1" {
-		t.Errorf("GetConfigurationToken() = %v, want %v", token, "config1")
+	if token := exchange.GetConfigurationToken(); token != testCaptureConfigToken {
+		t.Errorf("GetConfigurationToken() = %v, want %v", token, testCaptureConfigToken)
 	}
 
 	if token := exchange.GetVideoSourceToken(); token != "video1" {
@@ -102,22 +107,22 @@ func TestCapturedExchangeV2_GetTokens_Empty(t *testing.T) {
 
 func TestBuildMatchKey(t *testing.T) {
 	params := map[string]interface{}{
-		"ProfileToken":       "profile1",
-		"ConfigurationToken": "config1",
+		"ProfileToken":       testCaptureProfileToken,
+		"ConfigurationToken": testCaptureConfigToken,
 	}
 
-	key := BuildMatchKey("GetStreamURI", params)
+	key := BuildMatchKey(opGetStreamURI, params)
 
-	if key.OperationName != "GetStreamURI" {
-		t.Errorf("OperationName = %v, want %v", key.OperationName, "GetStreamURI")
+	if key.OperationName != opGetStreamURI {
+		t.Errorf("OperationName = %v, want %v", key.OperationName, opGetStreamURI)
 	}
 
-	if key.ProfileToken != "profile1" {
-		t.Errorf("ProfileToken = %v, want %v", key.ProfileToken, "profile1")
+	if key.ProfileToken != testCaptureProfileToken {
+		t.Errorf("ProfileToken = %v, want %v", key.ProfileToken, testCaptureProfileToken)
 	}
 
-	if key.ConfigurationToken != "config1" {
-		t.Errorf("ConfigurationToken = %v, want %v", key.ConfigurationToken, "config1")
+	if key.ConfigurationToken != testCaptureConfigToken {
+		t.Errorf("ConfigurationToken = %v, want %v", key.ConfigurationToken, testCaptureConfigToken)
 	}
 }
 
@@ -130,26 +135,26 @@ func TestMatchKey_MatchScore(t *testing.T) {
 	}{
 		{
 			name:     "Different operations",
-			key1:     MatchKey{OperationName: "GetProfiles"},
-			key2:     MatchKey{OperationName: "GetStreamURI"},
+			key1:     MatchKey{OperationName: opGetProfiles},
+			key2:     MatchKey{OperationName: opGetStreamURI},
 			expected: -1,
 		},
 		{
 			name:     "Same operation only",
-			key1:     MatchKey{OperationName: "GetProfiles"},
-			key2:     MatchKey{OperationName: "GetProfiles"},
+			key1:     MatchKey{OperationName: opGetProfiles},
+			key2:     MatchKey{OperationName: opGetProfiles},
 			expected: 1,
 		},
 		{
 			name:     "Same operation with matching profile",
-			key1:     MatchKey{OperationName: "GetStreamURI", ProfileToken: "profile1"},
-			key2:     MatchKey{OperationName: "GetStreamURI", ProfileToken: "profile1"},
+			key1:     MatchKey{OperationName: opGetStreamURI, ProfileToken: testCaptureProfileToken},
+			key2:     MatchKey{OperationName: opGetStreamURI, ProfileToken: testCaptureProfileToken},
 			expected: 11, // 1 + 10
 		},
 		{
 			name:     "Same operation with non-matching profile",
-			key1:     MatchKey{OperationName: "GetStreamURI", ProfileToken: "profile1"},
-			key2:     MatchKey{OperationName: "GetStreamURI", ProfileToken: "profile2"},
+			key1:     MatchKey{OperationName: opGetStreamURI, ProfileToken: testCaptureProfileToken},
+			key2:     MatchKey{OperationName: opGetStreamURI, ProfileToken: "profile2"},
 			expected: 1,
 		},
 	}
@@ -204,7 +209,7 @@ func TestConvertV1ToV2(t *testing.T) {
 	v1 := &CapturedExchange{
 		Timestamp:     "2025-01-01T00:00:00Z",
 		Operation:     1,
-		OperationName: "GetDeviceInformation",
+		OperationName: opGetDeviceInformation,
 		Endpoint:      "http://camera/onvif/device_service",
 		RequestBody:   "<request/>",
 		ResponseBody:  "<response/>",

--- a/testing/golden.go
+++ b/testing/golden.go
@@ -116,6 +116,7 @@ func buildGoldenKey(g *GoldenFile) string {
 			key += "_" + k + "_" + v
 		}
 	}
+
 	return key
 }
 
@@ -212,6 +213,7 @@ func isVariableField(field string, variableFields []string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -278,6 +280,7 @@ func GenerateGoldenFileName(operation string, params map[string]string) string {
 		v = strings.ReplaceAll(v, "\\", "_")
 		name += "_" + k + "_" + v
 	}
+
 	return name + ".json"
 }
 

--- a/testing/mock_server.go
+++ b/testing/mock_server.go
@@ -260,6 +260,7 @@ func NewMockSOAPServerV2(archivePath string) (*MockSOAPServerV2, error) {
 	}
 
 	mock.Server = httptest.NewServer(http.HandlerFunc(mock.handleRequest))
+
 	return mock, nil
 }
 
@@ -272,6 +273,7 @@ func processArchiveEntry(header *tar.Header, data []byte, capture *CameraCapture
 		if err := json.Unmarshal(data, &meta); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
 		}
+
 		return &meta, nil
 	}
 
@@ -300,6 +302,7 @@ func parseExchange(fileName string, data []byte) (*CapturedExchangeV2, error) {
 		if err := json.Unmarshal(data, &exchange); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal V2 %s: %w", fileName, err)
 		}
+
 		return &exchange, nil
 	}
 
@@ -312,6 +315,7 @@ func parseExchange(fileName string, data []byte) (*CapturedExchangeV2, error) {
 	// Extract parameters from V1 request body
 	v2Exchange.Parameters = ExtractParameters(v2Exchange.OperationName, v2Exchange.RequestBody)
 	v2Exchange.ServiceType = DetermineServiceType(v2Exchange.RequestBody)
+
 	return v2Exchange, nil
 }
 
@@ -371,6 +375,7 @@ func LoadCaptureFromArchiveV2(archivePath string) (*CameraCaptureV2, *CaptureMet
 	}
 
 	capture.Metadata = metadata
+
 	return capture, metadata, nil
 }
 
@@ -379,12 +384,14 @@ func (m *MockSOAPServerV2) handleRequest(w http.ResponseWriter, r *http.Request)
 	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read request", http.StatusBadRequest)
+
 		return
 	}
 
 	operationName := extractOperationFromSOAP(string(reqBody))
 	if operationName == "" {
 		http.Error(w, "Could not extract operation name from request", http.StatusBadRequest)
+
 		return
 	}
 
@@ -392,6 +399,7 @@ func (m *MockSOAPServerV2) handleRequest(w http.ResponseWriter, r *http.Request)
 	exchanges, ok := m.exchangeMap[operationName]
 	if !ok || len(exchanges) == 0 {
 		http.Error(w, fmt.Sprintf("No capture found for operation: %s", operationName), http.StatusNotFound)
+
 		return
 	}
 
@@ -450,6 +458,7 @@ func (m *MockSOAPServerV2) GetOperations() []string {
 	for op := range m.exchangeMap {
 		ops = append(ops, op)
 	}
+
 	return ops
 }
 
@@ -460,9 +469,9 @@ func (m *MockSOAPServerV2) GetOperations() []string {
 // tokenParams are common ONVIF token parameters to extract.
 var tokenParams = []string{
 	// Core tokens
-	"ProfileToken",
-	"ConfigurationToken",
-	"VideoSourceToken",
+	tokenProfile,
+	tokenConfiguration,
+	tokenVideoSource,
 	"AudioSourceToken",
 	"PresetToken",
 	"Token",
@@ -479,9 +488,9 @@ var tokenParams = []string{
 	"OSDToken",
 	"NodeToken",
 	"RelayOutputToken",
-	"VideoOutputToken",
+	tokenVideoOutput,
 	"DigitalInputToken",
-	"SerialPortToken",
+	tokenSerialPort,
 	"StorageConfigurationToken",
 	"CertificateID",
 	"RecordingToken",

--- a/testing/operations.go
+++ b/testing/operations.go
@@ -392,7 +392,7 @@ var DeviceIOReadOperations = []OperationSpec{
 
 // AllReadOperations returns all READ operations across all services.
 func AllReadOperations() []OperationSpec {
-	var all []OperationSpec
+	all := make([]OperationSpec, 0, len(DeviceReadOperations)+len(MediaReadOperations)+len(PTZReadOperations)+len(ImagingReadOperations)+len(EventReadOperations)+len(DeviceIOReadOperations))
 	all = append(all, DeviceReadOperations...)
 	all = append(all, MediaReadOperations...)
 	all = append(all, PTZReadOperations...)

--- a/testing/operations.go
+++ b/testing/operations.go
@@ -1,9 +1,57 @@
 // Package onviftesting provides testing utilities for ONVIF client testing.
 package onviftesting
 
+// ONVIF token parameter names, shared between OperationSpec.RequiresToken
+// entries below and the parameter extraction logic in mock_server.go.
+const (
+	tokenProfile       = "ProfileToken"
+	tokenConfiguration = "ConfigurationToken"
+	tokenVideoSource   = "VideoSourceToken"
+	tokenVideoOutput   = "VideoOutputToken"
+	tokenSerialPort    = "SerialPortToken"
+)
+
+// Operation category labels used across OperationSpec.Category entries.
+const (
+	categoryCore         = "core"
+	categorySystem       = "system"
+	categoryNetwork      = "network"
+	categorySecurity     = "security"
+	categoryCertificates = "certificates"
+	categoryAdditional   = "additional"
+	categoryWiFi         = "wifi"
+	categoryAudio        = "audio"
+	categoryAnalytics    = "analytics"
+	categoryVideo        = "video"
+	categoryEncoder      = "encoder"
+	categoryMetadata     = "metadata"
+	categoryOSD          = "osd"
+	categoryOutputs      = "outputs"
+	categorySerial       = "serial"
+)
+
+// ONVIF operation names referenced as both an operation's Name and as the
+// DependsOn value of operations that require a token it provides.
+const (
+	opGetProfiles                   = "GetProfiles"
+	opGetVideoSources               = "GetVideoSources"
+	opGetVideoSourceConfigurations  = "GetVideoSourceConfigurations"
+	opGetVideoEncoderConfigurations = "GetVideoEncoderConfigurations"
+	opGetAudioSourceConfigurations  = "GetAudioSourceConfigurations"
+	opGetAudioEncoderConfigurations = "GetAudioEncoderConfigurations"
+	opGetAudioOutputConfigurations  = "GetAudioOutputConfigurations"
+	opGetAudioDecoderConfigurations = "GetAudioDecoderConfigurations"
+	opGetMetadataConfigurations     = "GetMetadataConfigurations"
+	opGetOSDs                       = "GetOSDs"
+	opGetVideoOutputs               = "GetVideoOutputs"
+	opGetSerialPorts                = "GetSerialPorts"
+	opGetStreamURI                  = "GetStreamURI"
+	opGetDeviceInformation          = "GetDeviceInformation"
+)
+
 // OperationSpec defines how to capture an ONVIF operation.
 type OperationSpec struct {
-	// Name is the ONVIF operation name (e.g., "GetDeviceInformation")
+	// Name is the ONVIF operation name (e.g., opGetDeviceInformation)
 	Name string
 
 	// Service is the ONVIF service type
@@ -12,13 +60,13 @@ type OperationSpec struct {
 	// RequiresInit indicates if Initialize() must be called first
 	RequiresInit bool
 
-	// RequiresToken specifies which token parameter is needed (e.g., "ProfileToken")
+	// RequiresToken specifies which token parameter is needed (e.g., tokenProfile)
 	RequiresToken string
 
 	// DependsOn specifies which operation provides the required token
 	DependsOn string
 
-	// Category groups related operations (e.g., "core", "network", "security")
+	// Category groups related operations (e.g., categoryCore, categoryNetwork, categorySecurity)
 	Category string
 
 	// IsWrite indicates if this operation modifies camera state
@@ -35,39 +83,39 @@ type OperationSpec struct {
 // DeviceReadOperations contains all read-only Device service operations.
 var DeviceReadOperations = []OperationSpec{
 	// Core operations
-	{Name: "GetDeviceInformation", Service: ServiceDevice, Category: "core",
+	{Name: opGetDeviceInformation, Service: ServiceDevice, Category: categoryCore,
 		Description: "Get manufacturer, model, firmware version"},
-	{Name: "GetCapabilities", Service: ServiceDevice, Category: "core",
+	{Name: "GetCapabilities", Service: ServiceDevice, Category: categoryCore,
 		Description: "Get service capabilities and endpoints"},
-	{Name: "GetServices", Service: ServiceDevice, Category: "core",
+	{Name: "GetServices", Service: ServiceDevice, Category: categoryCore,
 		Description: "Get list of available services"},
-	{Name: "GetServiceCapabilities", Service: ServiceDevice, Category: "core",
+	{Name: "GetServiceCapabilities", Service: ServiceDevice, Category: categoryCore,
 		Description: "Get device service capabilities"},
 
 	// System operations
-	{Name: "GetSystemDateAndTime", Service: ServiceDevice, Category: "system",
+	{Name: "GetSystemDateAndTime", Service: ServiceDevice, Category: categorySystem,
 		Description: "Get device date and time settings"},
-	{Name: "GetSystemLog", Service: ServiceDevice, Category: "system",
+	{Name: "GetSystemLog", Service: ServiceDevice, Category: categorySystem,
 		Description: "Get system log"},
-	{Name: "GetSystemUris", Service: ServiceDevice, Category: "system",
+	{Name: "GetSystemUris", Service: ServiceDevice, Category: categorySystem,
 		Description: "Get system URIs (support, firmware, logs)"},
-	{Name: "GetSystemSupportInformation", Service: ServiceDevice, Category: "system",
+	{Name: "GetSystemSupportInformation", Service: ServiceDevice, Category: categorySystem,
 		Description: "Get system support information"},
-	{Name: "GetEndpointReference", Service: ServiceDevice, Category: "system",
+	{Name: "GetEndpointReference", Service: ServiceDevice, Category: categorySystem,
 		Description: "Get unique endpoint reference address"},
 
 	// Network operations
-	{Name: "GetHostname", Service: ServiceDevice, Category: "network",
+	{Name: "GetHostname", Service: ServiceDevice, Category: categoryNetwork,
 		Description: "Get device hostname"},
-	{Name: "GetDNS", Service: ServiceDevice, Category: "network",
+	{Name: "GetDNS", Service: ServiceDevice, Category: categoryNetwork,
 		Description: "Get DNS configuration"},
-	{Name: "GetNTP", Service: ServiceDevice, Category: "network",
+	{Name: "GetNTP", Service: ServiceDevice, Category: categoryNetwork,
 		Description: "Get NTP configuration"},
-	{Name: "GetNetworkInterfaces", Service: ServiceDevice, Category: "network",
+	{Name: "GetNetworkInterfaces", Service: ServiceDevice, Category: categoryNetwork,
 		Description: "Get network interface configuration"},
-	{Name: "GetNetworkProtocols", Service: ServiceDevice, Category: "network",
+	{Name: "GetNetworkProtocols", Service: ServiceDevice, Category: categoryNetwork,
 		Description: "Get enabled network protocols"},
-	{Name: "GetNetworkDefaultGateway", Service: ServiceDevice, Category: "network",
+	{Name: "GetNetworkDefaultGateway", Service: ServiceDevice, Category: categoryNetwork,
 		Description: "Get default gateway configuration"},
 
 	// Discovery operations
@@ -85,31 +133,31 @@ var DeviceReadOperations = []OperationSpec{
 		Description: "Get list of device users"},
 
 	// Security operations
-	{Name: "GetRemoteUser", Service: ServiceDevice, Category: "security",
+	{Name: "GetRemoteUser", Service: ServiceDevice, Category: categorySecurity,
 		Description: "Get remote user configuration"},
-	{Name: "GetIPAddressFilter", Service: ServiceDevice, Category: "security",
+	{Name: "GetIPAddressFilter", Service: ServiceDevice, Category: categorySecurity,
 		Description: "Get IP address filter rules"},
-	{Name: "GetZeroConfiguration", Service: ServiceDevice, Category: "security",
+	{Name: "GetZeroConfiguration", Service: ServiceDevice, Category: categorySecurity,
 		Description: "Get zero configuration (link-local) settings"},
-	{Name: "GetDynamicDNS", Service: ServiceDevice, Category: "security",
+	{Name: "GetDynamicDNS", Service: ServiceDevice, Category: categorySecurity,
 		Description: "Get dynamic DNS configuration"},
-	{Name: "GetAccessPolicy", Service: ServiceDevice, Category: "security",
+	{Name: "GetAccessPolicy", Service: ServiceDevice, Category: categorySecurity,
 		Description: "Get access policy configuration"},
-	{Name: "GetPasswordComplexityConfiguration", Service: ServiceDevice, Category: "security",
+	{Name: "GetPasswordComplexityConfiguration", Service: ServiceDevice, Category: categorySecurity,
 		Description: "Get password complexity requirements"},
-	{Name: "GetPasswordHistoryConfiguration", Service: ServiceDevice, Category: "security",
+	{Name: "GetPasswordHistoryConfiguration", Service: ServiceDevice, Category: categorySecurity,
 		Description: "Get password history configuration"},
-	{Name: "GetAuthFailureWarningConfiguration", Service: ServiceDevice, Category: "security",
+	{Name: "GetAuthFailureWarningConfiguration", Service: ServiceDevice, Category: categorySecurity,
 		Description: "Get authentication failure warning settings"},
 
 	// Certificate operations
-	{Name: "GetCertificates", Service: ServiceDevice, Category: "certificates",
+	{Name: "GetCertificates", Service: ServiceDevice, Category: categoryCertificates,
 		Description: "Get device certificates"},
-	{Name: "GetCACertificates", Service: ServiceDevice, Category: "certificates",
+	{Name: "GetCACertificates", Service: ServiceDevice, Category: categoryCertificates,
 		Description: "Get CA certificates"},
-	{Name: "GetCertificatesStatus", Service: ServiceDevice, Category: "certificates",
+	{Name: "GetCertificatesStatus", Service: ServiceDevice, Category: categoryCertificates,
 		Description: "Get certificate status"},
-	{Name: "GetClientCertificateMode", Service: ServiceDevice, Category: "certificates",
+	{Name: "GetClientCertificateMode", Service: ServiceDevice, Category: categoryCertificates,
 		Description: "Get client certificate mode"},
 
 	// Storage operations
@@ -121,21 +169,21 @@ var DeviceReadOperations = []OperationSpec{
 		Description: "Get relay output states"},
 
 	// Additional operations
-	{Name: "GetGeoLocation", Service: ServiceDevice, Category: "additional",
+	{Name: "GetGeoLocation", Service: ServiceDevice, Category: categoryAdditional,
 		Description: "Get geographic location"},
-	{Name: "GetDPAddresses", Service: ServiceDevice, Category: "additional",
+	{Name: "GetDPAddresses", Service: ServiceDevice, Category: categoryAdditional,
 		Description: "Get DP (discovery proxy) addresses"},
-	{Name: "GetWsdlURL", Service: ServiceDevice, Category: "additional",
+	{Name: "GetWsdlURL", Service: ServiceDevice, Category: categoryAdditional,
 		Description: "Get WSDL URL"},
 
 	// WiFi operations (802.11)
-	{Name: "GetDot11Capabilities", Service: ServiceDevice, Category: "wifi",
+	{Name: "GetDot11Capabilities", Service: ServiceDevice, Category: categoryWiFi,
 		Description: "Get 802.11 capabilities"},
-	{Name: "GetDot11Status", Service: ServiceDevice, Category: "wifi",
+	{Name: "GetDot11Status", Service: ServiceDevice, Category: categoryWiFi,
 		Description: "Get 802.11 connection status"},
-	{Name: "GetDot1XConfigurations", Service: ServiceDevice, Category: "wifi",
+	{Name: "GetDot1XConfigurations", Service: ServiceDevice, Category: categoryWiFi,
 		Description: "Get 802.1X configurations"},
-	{Name: "ScanAvailableDot11Networks", Service: ServiceDevice, Category: "wifi",
+	{Name: "ScanAvailableDot11Networks", Service: ServiceDevice, Category: categoryWiFi,
 		Description: "Scan for available WiFi networks"},
 }
 
@@ -146,150 +194,150 @@ var DeviceReadOperations = []OperationSpec{
 // MediaReadOperations contains all read-only Media service operations.
 var MediaReadOperations = []OperationSpec{
 	// Service capabilities
-	{Name: "GetMediaServiceCapabilities", Service: ServiceMedia, RequiresInit: true, Category: "core",
+	{Name: "GetMediaServiceCapabilities", Service: ServiceMedia, RequiresInit: true, Category: categoryCore,
 		Description: "Get media service capabilities"},
 
 	// Profile operations
-	{Name: "GetProfiles", Service: ServiceMedia, RequiresInit: true, Category: "profiles",
+	{Name: opGetProfiles, Service: ServiceMedia, RequiresInit: true, Category: "profiles",
 		Description: "Get all media profiles"},
 	{Name: "GetProfile", Service: ServiceMedia, RequiresInit: true, Category: "profiles",
-		RequiresToken: "ProfileToken", DependsOn: "GetProfiles",
+		RequiresToken: tokenProfile, DependsOn: opGetProfiles,
 		Description: "Get specific profile by token"},
 
 	// Video source operations
-	{Name: "GetVideoSources", Service: ServiceMedia, RequiresInit: true, Category: "video",
+	{Name: opGetVideoSources, Service: ServiceMedia, RequiresInit: true, Category: categoryVideo,
 		Description: "Get video sources"},
-	{Name: "GetVideoSourceConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "video",
+	{Name: opGetVideoSourceConfigurations, Service: ServiceMedia, RequiresInit: true, Category: categoryVideo,
 		Description: "Get all video source configurations"},
-	{Name: "GetVideoSourceConfiguration", Service: ServiceMedia, RequiresInit: true, Category: "video",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetVideoSourceConfigurations",
+	{Name: "GetVideoSourceConfiguration", Service: ServiceMedia, RequiresInit: true, Category: categoryVideo,
+		RequiresToken: tokenConfiguration, DependsOn: opGetVideoSourceConfigurations,
 		Description: "Get specific video source configuration"},
-	{Name: "GetVideoSourceConfigurationOptions", Service: ServiceMedia, RequiresInit: true, Category: "video",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetVideoSourceConfigurations",
+	{Name: "GetVideoSourceConfigurationOptions", Service: ServiceMedia, RequiresInit: true, Category: categoryVideo,
+		RequiresToken: tokenConfiguration, DependsOn: opGetVideoSourceConfigurations,
 		Description: "Get video source configuration options"},
-	{Name: "GetVideoSourceModes", Service: ServiceMedia, RequiresInit: true, Category: "video",
-		RequiresToken: "VideoSourceToken", DependsOn: "GetVideoSources",
+	{Name: "GetVideoSourceModes", Service: ServiceMedia, RequiresInit: true, Category: categoryVideo,
+		RequiresToken: tokenVideoSource, DependsOn: opGetVideoSources,
 		Description: "Get video source modes"},
-	{Name: "GetCompatibleVideoSourceConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "video",
-		RequiresToken: "ProfileToken", DependsOn: "GetProfiles",
+	{Name: "GetCompatibleVideoSourceConfigurations", Service: ServiceMedia, RequiresInit: true, Category: categoryVideo,
+		RequiresToken: tokenProfile, DependsOn: opGetProfiles,
 		Description: "Get compatible video source configurations for profile"},
 
 	// Video encoder operations
-	{Name: "GetVideoEncoderConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "encoder",
+	{Name: opGetVideoEncoderConfigurations, Service: ServiceMedia, RequiresInit: true, Category: categoryEncoder,
 		Description: "Get all video encoder configurations"},
-	{Name: "GetVideoEncoderConfiguration", Service: ServiceMedia, RequiresInit: true, Category: "encoder",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetVideoEncoderConfigurations",
+	{Name: "GetVideoEncoderConfiguration", Service: ServiceMedia, RequiresInit: true, Category: categoryEncoder,
+		RequiresToken: tokenConfiguration, DependsOn: opGetVideoEncoderConfigurations,
 		Description: "Get specific video encoder configuration"},
-	{Name: "GetVideoEncoderConfigurationOptions", Service: ServiceMedia, RequiresInit: true, Category: "encoder",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetVideoEncoderConfigurations",
+	{Name: "GetVideoEncoderConfigurationOptions", Service: ServiceMedia, RequiresInit: true, Category: categoryEncoder,
+		RequiresToken: tokenConfiguration, DependsOn: opGetVideoEncoderConfigurations,
 		Description: "Get video encoder configuration options"},
-	{Name: "GetCompatibleVideoEncoderConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "encoder",
-		RequiresToken: "ProfileToken", DependsOn: "GetProfiles",
+	{Name: "GetCompatibleVideoEncoderConfigurations", Service: ServiceMedia, RequiresInit: true, Category: categoryEncoder,
+		RequiresToken: tokenProfile, DependsOn: opGetProfiles,
 		Description: "Get compatible video encoder configurations for profile"},
-	{Name: "GetGuaranteedNumberOfVideoEncoderInstances", Service: ServiceMedia, RequiresInit: true, Category: "encoder",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetVideoEncoderConfigurations",
+	{Name: "GetGuaranteedNumberOfVideoEncoderInstances", Service: ServiceMedia, RequiresInit: true, Category: categoryEncoder,
+		RequiresToken: tokenConfiguration, DependsOn: opGetVideoEncoderConfigurations,
 		Description: "Get guaranteed number of video encoder instances"},
 
 	// Audio source operations
-	{Name: "GetAudioSources", Service: ServiceMedia, RequiresInit: true, Category: "audio",
+	{Name: "GetAudioSources", Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
 		Description: "Get audio sources"},
-	{Name: "GetAudioSourceConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "audio",
+	{Name: opGetAudioSourceConfigurations, Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
 		Description: "Get all audio source configurations"},
-	{Name: "GetAudioSourceConfiguration", Service: ServiceMedia, RequiresInit: true, Category: "audio",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetAudioSourceConfigurations",
+	{Name: "GetAudioSourceConfiguration", Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
+		RequiresToken: tokenConfiguration, DependsOn: opGetAudioSourceConfigurations,
 		Description: "Get specific audio source configuration"},
-	{Name: "GetAudioSourceConfigurationOptions", Service: ServiceMedia, RequiresInit: true, Category: "audio",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetAudioSourceConfigurations",
+	{Name: "GetAudioSourceConfigurationOptions", Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
+		RequiresToken: tokenConfiguration, DependsOn: opGetAudioSourceConfigurations,
 		Description: "Get audio source configuration options"},
-	{Name: "GetCompatibleAudioSourceConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "audio",
-		RequiresToken: "ProfileToken", DependsOn: "GetProfiles",
+	{Name: "GetCompatibleAudioSourceConfigurations", Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
+		RequiresToken: tokenProfile, DependsOn: opGetProfiles,
 		Description: "Get compatible audio source configurations for profile"},
 
 	// Audio encoder operations
-	{Name: "GetAudioEncoderConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "audio",
+	{Name: opGetAudioEncoderConfigurations, Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
 		Description: "Get all audio encoder configurations"},
-	{Name: "GetAudioEncoderConfiguration", Service: ServiceMedia, RequiresInit: true, Category: "audio",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetAudioEncoderConfigurations",
+	{Name: "GetAudioEncoderConfiguration", Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
+		RequiresToken: tokenConfiguration, DependsOn: opGetAudioEncoderConfigurations,
 		Description: "Get specific audio encoder configuration"},
-	{Name: "GetAudioEncoderConfigurationOptions", Service: ServiceMedia, RequiresInit: true, Category: "audio",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetAudioEncoderConfigurations",
+	{Name: "GetAudioEncoderConfigurationOptions", Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
+		RequiresToken: tokenConfiguration, DependsOn: opGetAudioEncoderConfigurations,
 		Description: "Get audio encoder configuration options"},
-	{Name: "GetCompatibleAudioEncoderConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "audio",
-		RequiresToken: "ProfileToken", DependsOn: "GetProfiles",
+	{Name: "GetCompatibleAudioEncoderConfigurations", Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
+		RequiresToken: tokenProfile, DependsOn: opGetProfiles,
 		Description: "Get compatible audio encoder configurations for profile"},
 
 	// Audio output operations
-	{Name: "GetAudioOutputs", Service: ServiceMedia, RequiresInit: true, Category: "audio",
+	{Name: "GetAudioOutputs", Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
 		Description: "Get audio outputs"},
-	{Name: "GetAudioOutputConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "audio",
+	{Name: opGetAudioOutputConfigurations, Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
 		Description: "Get all audio output configurations"},
-	{Name: "GetAudioOutputConfiguration", Service: ServiceMedia, RequiresInit: true, Category: "audio",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetAudioOutputConfigurations",
+	{Name: "GetAudioOutputConfiguration", Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
+		RequiresToken: tokenConfiguration, DependsOn: opGetAudioOutputConfigurations,
 		Description: "Get specific audio output configuration"},
-	{Name: "GetAudioOutputConfigurationOptions", Service: ServiceMedia, RequiresInit: true, Category: "audio",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetAudioOutputConfigurations",
+	{Name: "GetAudioOutputConfigurationOptions", Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
+		RequiresToken: tokenConfiguration, DependsOn: opGetAudioOutputConfigurations,
 		Description: "Get audio output configuration options"},
-	{Name: "GetCompatibleAudioOutputConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "audio",
-		RequiresToken: "ProfileToken", DependsOn: "GetProfiles",
+	{Name: "GetCompatibleAudioOutputConfigurations", Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
+		RequiresToken: tokenProfile, DependsOn: opGetProfiles,
 		Description: "Get compatible audio output configurations for profile"},
 
 	// Audio decoder operations
-	{Name: "GetAudioDecoderConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "audio",
+	{Name: opGetAudioDecoderConfigurations, Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
 		Description: "Get all audio decoder configurations"},
-	{Name: "GetAudioDecoderConfiguration", Service: ServiceMedia, RequiresInit: true, Category: "audio",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetAudioDecoderConfigurations",
+	{Name: "GetAudioDecoderConfiguration", Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
+		RequiresToken: tokenConfiguration, DependsOn: opGetAudioDecoderConfigurations,
 		Description: "Get specific audio decoder configuration"},
-	{Name: "GetAudioDecoderConfigurationOptions", Service: ServiceMedia, RequiresInit: true, Category: "audio",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetAudioDecoderConfigurations",
+	{Name: "GetAudioDecoderConfigurationOptions", Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
+		RequiresToken: tokenConfiguration, DependsOn: opGetAudioDecoderConfigurations,
 		Description: "Get audio decoder configuration options"},
-	{Name: "GetCompatibleAudioDecoderConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "audio",
-		RequiresToken: "ProfileToken", DependsOn: "GetProfiles",
+	{Name: "GetCompatibleAudioDecoderConfigurations", Service: ServiceMedia, RequiresInit: true, Category: categoryAudio,
+		RequiresToken: tokenProfile, DependsOn: opGetProfiles,
 		Description: "Get compatible audio decoder configurations for profile"},
 
 	// Metadata operations
-	{Name: "GetMetadataConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "metadata",
+	{Name: opGetMetadataConfigurations, Service: ServiceMedia, RequiresInit: true, Category: categoryMetadata,
 		Description: "Get all metadata configurations"},
-	{Name: "GetMetadataConfiguration", Service: ServiceMedia, RequiresInit: true, Category: "metadata",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetMetadataConfigurations",
+	{Name: "GetMetadataConfiguration", Service: ServiceMedia, RequiresInit: true, Category: categoryMetadata,
+		RequiresToken: tokenConfiguration, DependsOn: opGetMetadataConfigurations,
 		Description: "Get specific metadata configuration"},
-	{Name: "GetMetadataConfigurationOptions", Service: ServiceMedia, RequiresInit: true, Category: "metadata",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetMetadataConfigurations",
+	{Name: "GetMetadataConfigurationOptions", Service: ServiceMedia, RequiresInit: true, Category: categoryMetadata,
+		RequiresToken: tokenConfiguration, DependsOn: opGetMetadataConfigurations,
 		Description: "Get metadata configuration options"},
-	{Name: "GetCompatibleMetadataConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "metadata",
-		RequiresToken: "ProfileToken", DependsOn: "GetProfiles",
+	{Name: "GetCompatibleMetadataConfigurations", Service: ServiceMedia, RequiresInit: true, Category: categoryMetadata,
+		RequiresToken: tokenProfile, DependsOn: opGetProfiles,
 		Description: "Get compatible metadata configurations for profile"},
 
 	// Video analytics operations
-	{Name: "GetVideoAnalyticsConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "analytics",
+	{Name: "GetVideoAnalyticsConfigurations", Service: ServiceMedia, RequiresInit: true, Category: categoryAnalytics,
 		Description: "Get all video analytics configurations"},
-	{Name: "GetVideoAnalyticsConfiguration", Service: ServiceMedia, RequiresInit: true, Category: "analytics",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetVideoAnalyticsConfigurations",
+	{Name: "GetVideoAnalyticsConfiguration", Service: ServiceMedia, RequiresInit: true, Category: categoryAnalytics,
+		RequiresToken: tokenConfiguration, DependsOn: "GetVideoAnalyticsConfigurations",
 		Description: "Get specific video analytics configuration"},
-	{Name: "GetCompatibleVideoAnalyticsConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "analytics",
-		RequiresToken: "ProfileToken", DependsOn: "GetProfiles",
+	{Name: "GetCompatibleVideoAnalyticsConfigurations", Service: ServiceMedia, RequiresInit: true, Category: categoryAnalytics,
+		RequiresToken: tokenProfile, DependsOn: opGetProfiles,
 		Description: "Get compatible video analytics configurations for profile"},
 
 	// Stream operations
-	{Name: "GetStreamURI", Service: ServiceMedia, RequiresInit: true, Category: "streaming",
-		RequiresToken: "ProfileToken", DependsOn: "GetProfiles",
+	{Name: opGetStreamURI, Service: ServiceMedia, RequiresInit: true, Category: "streaming",
+		RequiresToken: tokenProfile, DependsOn: opGetProfiles,
 		Description: "Get RTSP stream URI"},
 	{Name: "GetSnapshotURI", Service: ServiceMedia, RequiresInit: true, Category: "streaming",
-		RequiresToken: "ProfileToken", DependsOn: "GetProfiles",
+		RequiresToken: tokenProfile, DependsOn: opGetProfiles,
 		Description: "Get snapshot URI"},
 
 	// OSD operations
-	{Name: "GetOSDs", Service: ServiceMedia, RequiresInit: true, Category: "osd",
+	{Name: opGetOSDs, Service: ServiceMedia, RequiresInit: true, Category: categoryOSD,
 		Description: "Get all OSD configurations"},
-	{Name: "GetOSD", Service: ServiceMedia, RequiresInit: true, Category: "osd",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetOSDs",
+	{Name: "GetOSD", Service: ServiceMedia, RequiresInit: true, Category: categoryOSD,
+		RequiresToken: tokenConfiguration, DependsOn: opGetOSDs,
 		Description: "Get specific OSD configuration"},
-	{Name: "GetOSDOptions", Service: ServiceMedia, RequiresInit: true, Category: "osd",
-		RequiresToken: "ConfigurationToken", DependsOn: "GetOSDs",
+	{Name: "GetOSDOptions", Service: ServiceMedia, RequiresInit: true, Category: categoryOSD,
+		RequiresToken: tokenConfiguration, DependsOn: opGetOSDs,
 		Description: "Get OSD configuration options"},
 
 	// PTZ configuration operations (on Media service)
 	{Name: "GetCompatiblePTZConfigurations", Service: ServiceMedia, RequiresInit: true, Category: "ptz",
-		RequiresToken: "ProfileToken", DependsOn: "GetProfiles",
+		RequiresToken: tokenProfile, DependsOn: opGetProfiles,
 		Description: "Get compatible PTZ configurations for profile"},
 }
 
@@ -305,10 +353,10 @@ var PTZReadOperations = []OperationSpec{
 		RequiresToken: "PTZConfigurationToken", DependsOn: "GetConfigurations",
 		Description: "Get specific PTZ configuration"},
 	{Name: "GetStatus", Service: ServicePTZ, RequiresInit: true, Category: "status",
-		RequiresToken: "ProfileToken", DependsOn: "GetProfiles",
+		RequiresToken: tokenProfile, DependsOn: opGetProfiles,
 		Description: "Get PTZ status (position, move status)"},
 	{Name: "GetPresets", Service: ServicePTZ, RequiresInit: true, Category: "presets",
-		RequiresToken: "ProfileToken", DependsOn: "GetProfiles",
+		RequiresToken: tokenProfile, DependsOn: opGetProfiles,
 		Description: "Get PTZ presets"},
 	{Name: "GetNodes", Service: ServicePTZ, RequiresInit: true, Category: "nodes",
 		Description: "Get PTZ nodes"},
@@ -324,16 +372,16 @@ var PTZReadOperations = []OperationSpec{
 // ImagingReadOperations contains all read-only Imaging service operations.
 var ImagingReadOperations = []OperationSpec{
 	{Name: "GetImagingSettings", Service: ServiceImaging, RequiresInit: true, Category: "settings",
-		RequiresToken: "VideoSourceToken", DependsOn: "GetVideoSources",
+		RequiresToken: tokenVideoSource, DependsOn: opGetVideoSources,
 		Description: "Get imaging settings (brightness, contrast, etc.)"},
 	{Name: "GetOptions", Service: ServiceImaging, RequiresInit: true, Category: "options",
-		RequiresToken: "VideoSourceToken", DependsOn: "GetVideoSources",
+		RequiresToken: tokenVideoSource, DependsOn: opGetVideoSources,
 		Description: "Get imaging options and ranges"},
 	{Name: "GetMoveOptions", Service: ServiceImaging, RequiresInit: true, Category: "options",
-		RequiresToken: "VideoSourceToken", DependsOn: "GetVideoSources",
+		RequiresToken: tokenVideoSource, DependsOn: opGetVideoSources,
 		Description: "Get focus move options"},
 	{Name: "GetImagingStatus", Service: ServiceImaging, RequiresInit: true, Category: "status",
-		RequiresToken: "VideoSourceToken", DependsOn: "GetVideoSources",
+		RequiresToken: tokenVideoSource, DependsOn: opGetVideoSources,
 		Description: "Get imaging status (focus status, etc.)"},
 }
 
@@ -343,9 +391,9 @@ var ImagingReadOperations = []OperationSpec{
 
 // EventReadOperations contains all read-only Event service operations.
 var EventReadOperations = []OperationSpec{
-	{Name: "GetEventServiceCapabilities", Service: ServiceEvent, RequiresInit: true, Category: "core",
+	{Name: "GetEventServiceCapabilities", Service: ServiceEvent, RequiresInit: true, Category: categoryCore,
 		Description: "Get event service capabilities"},
-	{Name: "GetEventProperties", Service: ServiceEvent, RequiresInit: true, Category: "core",
+	{Name: "GetEventProperties", Service: ServiceEvent, RequiresInit: true, Category: categoryCore,
 		Description: "Get event topic properties"},
 	{Name: "GetEventBrokers", Service: ServiceEvent, RequiresInit: true, Category: "brokers",
 		Description: "Get event brokers"},
@@ -357,32 +405,32 @@ var EventReadOperations = []OperationSpec{
 
 // DeviceIOReadOperations contains all read-only DeviceIO service operations.
 var DeviceIOReadOperations = []OperationSpec{
-	{Name: "GetDeviceIOServiceCapabilities", Service: ServiceDeviceIO, RequiresInit: true, Category: "core",
+	{Name: "GetDeviceIOServiceCapabilities", Service: ServiceDeviceIO, RequiresInit: true, Category: categoryCore,
 		Description: "Get DeviceIO service capabilities"},
 	{Name: "GetDigitalInputs", Service: ServiceDeviceIO, RequiresInit: true, Category: "inputs",
 		Description: "Get digital inputs"},
 	{Name: "GetDigitalInputConfigurationOptions", Service: ServiceDeviceIO, RequiresInit: true, Category: "inputs",
 		Description: "Get digital input configuration options"},
-	{Name: "GetVideoOutputs", Service: ServiceDeviceIO, RequiresInit: true, Category: "outputs",
+	{Name: opGetVideoOutputs, Service: ServiceDeviceIO, RequiresInit: true, Category: categoryOutputs,
 		Description: "Get video outputs"},
-	{Name: "GetVideoOutputConfiguration", Service: ServiceDeviceIO, RequiresInit: true, Category: "outputs",
-		RequiresToken: "VideoOutputToken", DependsOn: "GetVideoOutputs",
+	{Name: "GetVideoOutputConfiguration", Service: ServiceDeviceIO, RequiresInit: true, Category: categoryOutputs,
+		RequiresToken: tokenVideoOutput, DependsOn: opGetVideoOutputs,
 		Description: "Get video output configuration"},
-	{Name: "GetVideoOutputConfigurationOptions", Service: ServiceDeviceIO, RequiresInit: true, Category: "outputs",
-		RequiresToken: "VideoOutputToken", DependsOn: "GetVideoOutputs",
+	{Name: "GetVideoOutputConfigurationOptions", Service: ServiceDeviceIO, RequiresInit: true, Category: categoryOutputs,
+		RequiresToken: tokenVideoOutput, DependsOn: opGetVideoOutputs,
 		Description: "Get video output configuration options"},
-	{Name: "GetSerialPorts", Service: ServiceDeviceIO, RequiresInit: true, Category: "serial",
+	{Name: opGetSerialPorts, Service: ServiceDeviceIO, RequiresInit: true, Category: categorySerial,
 		Description: "Get serial ports"},
-	{Name: "GetSerialPortConfiguration", Service: ServiceDeviceIO, RequiresInit: true, Category: "serial",
-		RequiresToken: "SerialPortToken", DependsOn: "GetSerialPorts",
+	{Name: "GetSerialPortConfiguration", Service: ServiceDeviceIO, RequiresInit: true, Category: categorySerial,
+		RequiresToken: tokenSerialPort, DependsOn: opGetSerialPorts,
 		Description: "Get serial port configuration"},
-	{Name: "GetSerialPortConfigurationOptions", Service: ServiceDeviceIO, RequiresInit: true, Category: "serial",
-		RequiresToken: "SerialPortToken", DependsOn: "GetSerialPorts",
+	{Name: "GetSerialPortConfigurationOptions", Service: ServiceDeviceIO, RequiresInit: true, Category: categorySerial,
+		RequiresToken: tokenSerialPort, DependsOn: opGetSerialPorts,
 		Description: "Get serial port configuration options"},
 	{Name: "GetRelayOutputOptions", Service: ServiceDeviceIO, RequiresInit: true, Category: "relay",
 		RequiresToken: "RelayOutputToken",
 		Description:   "Get relay output options"},
-	{Name: "GetAudioOutputs", Service: ServiceDeviceIO, RequiresInit: true, Category: "audio",
+	{Name: "GetAudioOutputs", Service: ServiceDeviceIO, RequiresInit: true, Category: categoryAudio,
 		Description: "Get audio outputs (DeviceIO)"},
 }
 
@@ -399,6 +447,7 @@ func AllReadOperations() []OperationSpec {
 	all = append(all, ImagingReadOperations...)
 	all = append(all, EventReadOperations...)
 	all = append(all, DeviceIOReadOperations...)
+
 	return all
 }
 
@@ -420,6 +469,7 @@ func ReadOperationsByService(service ServiceType) []OperationSpec {
 	case ServiceUnknown:
 		return nil
 	}
+
 	return nil
 }
 
@@ -431,6 +481,7 @@ func IndependentOperations() []OperationSpec {
 			independent = append(independent, op)
 		}
 	}
+
 	return independent
 }
 
@@ -442,6 +493,7 @@ func DependentOperations() []OperationSpec {
 			dependent = append(dependent, op)
 		}
 	}
+
 	return dependent
 }
 
@@ -453,6 +505,7 @@ func OperationsByDependency(dependsOn string) []OperationSpec {
 			ops = append(ops, op)
 		}
 	}
+
 	return ops
 }
 
@@ -488,6 +541,7 @@ func GetOperationSpec(name string) *OperationSpec {
 			return &DeviceIOReadOperations[i]
 		}
 	}
+
 	return nil
 }
 

--- a/testing/operations_test.go
+++ b/testing/operations_test.go
@@ -105,14 +105,14 @@ func TestDependentOperations(t *testing.T) {
 
 func TestOperationsByDependency(t *testing.T) {
 	// GetProfiles is a common dependency
-	ops := OperationsByDependency("GetProfiles")
+	ops := OperationsByDependency(opGetProfiles)
 
 	if len(ops) == 0 {
 		t.Error("Operations depending on GetProfiles should exist")
 	}
 
 	for _, op := range ops {
-		if op.DependsOn != "GetProfiles" {
+		if op.DependsOn != opGetProfiles {
 			t.Errorf("Operation %s has DependsOn=%s, want GetProfiles",
 				op.Name, op.DependsOn)
 		}
@@ -124,9 +124,9 @@ func TestGetOperationSpec(t *testing.T) {
 		name     string
 		expected bool
 	}{
-		{"GetDeviceInformation", true},
-		{"GetProfiles", true},
-		{"GetStreamURI", true},
+		{opGetDeviceInformation, true},
+		{opGetProfiles, true},
+		{opGetStreamURI, true},
 		{"GetStatus", true},
 		{"NonExistentOperation", false},
 	}
@@ -160,7 +160,7 @@ func TestOperationSpec_DependencyChain(t *testing.T) {
 func TestDeviceReadOperations(t *testing.T) {
 	// Check for expected core operations
 	expectedOps := []string{
-		"GetDeviceInformation",
+		opGetDeviceInformation,
 		"GetCapabilities",
 		"GetSystemDateAndTime",
 		"GetHostname",
@@ -187,11 +187,11 @@ func TestDeviceReadOperations(t *testing.T) {
 func TestMediaReadOperations(t *testing.T) {
 	// Check for expected core operations
 	expectedOps := []string{
-		"GetProfiles",
+		opGetProfiles,
 		"GetProfile",
 		"GetVideoSources",
 		"GetAudioSources",
-		"GetStreamURI",
+		opGetStreamURI,
 		"GetSnapshotURI",
 		"GetVideoEncoderConfigurations",
 	}

--- a/testing/registry.go
+++ b/testing/registry.go
@@ -60,6 +60,7 @@ func LoadRegistry(path string) (*Registry, error) {
 				Coverage:    make(map[string]Coverage),
 			}, nil
 		}
+
 		return nil, fmt.Errorf("failed to read registry: %w", err)
 	}
 
@@ -101,6 +102,7 @@ func (r *Registry) AddCamera(entry *CameraEntry) {
 		if cam.ID == entry.ID {
 			// Update existing entry
 			r.Cameras[i] = *entry
+
 			return
 		}
 	}
@@ -119,6 +121,7 @@ func (r *Registry) GetCamera(id string) *CameraEntry {
 			return &r.Cameras[i]
 		}
 	}
+
 	return nil
 }
 
@@ -128,6 +131,7 @@ func (r *Registry) RemoveCamera(id string) bool {
 		cam := &r.Cameras[i]
 		if cam.ID == id {
 			r.Cameras = append(r.Cameras[:i], r.Cameras[i+1:]...)
+
 			return true
 		}
 	}
@@ -143,6 +147,7 @@ func (r *Registry) GetCamerasByManufacturer(manufacturer string) []*CameraEntry 
 			cameras = append(cameras, &r.Cameras[i])
 		}
 	}
+
 	return cameras
 }
 
@@ -174,6 +179,7 @@ func (r *Registry) GetTotalCoverage() (total, captured int) {
 		total += cov.Total
 		captured += cov.Captured
 	}
+
 	return total, captured
 }
 
@@ -182,6 +188,7 @@ func GenerateCameraID(manufacturer, model, firmware string) string {
 	// Sanitize and combine
 	id := fmt.Sprintf("%s_%s_%s", manufacturer, model, firmware)
 	id = sanitizeID(id)
+
 	return id
 }
 
@@ -201,6 +208,7 @@ func sanitizeID(s string) string {
 			result = append(result, '_')
 		}
 	}
+
 	return string(result)
 }
 
@@ -338,6 +346,7 @@ func findSubstring(s, substr string) int {
 			return i
 		}
 	}
+
 	return -1
 }
 


### PR DESCRIPTION
## Summary

Completes issue #59 by fixing the remaining goconst/nlreturn/prealloc lint debt. **A previous pass on this branch under-reported the true state of the work** — it judged completion using a plain `golangci-lint run`, which silently applies the CLI defaults `--max-issues-per-linter=50` and `--max-same-issues=3`. Because every `nlreturn` violation shares the identical message text ("return with no blank line before (nlreturn)"), the same-issue cap collapsed 70+ real occurrences down to 3 shown; `goconst` was similarly capped at 50 shown. The previous pass's PR description claimed goconst(50)/nlreturn(3)/prealloc(3) were "now at 0" — that was true only of the artificially capped view, not of the codebase.

**Ground truth requires disabling both caps explicitly:**
```
golangci-lint run --timeout=5m --max-issues-per-linter=0 --max-same-issues=0 ./...
```

### True counts (uncapped)

| Stage | goconst | nlreturn | prealloc | unused |
|---|---|---|---|---|
| master baseline | 107 | 76 | 3 | 0 |
| previous pass end state | 71 | 73 | 0 | 6 (regression) |
| this pass end state | 0 | 0 | 0 | 0 |

The previous pass made real progress on goconst (107→71) and prealloc (3→0), but barely touched nlreturn (76→73) and introduced 6 new `unused` findings — test constants that were declared but never referenced because the literal string at the use site was never actually swapped for the constant (in a few cases the code even compared against the constant's own *name* as a quoted string literal instead of its value).

## What this pass did, verified only against the uncapped output

- **Formatting**: ran `gofmt -s -w .` — 5 files were left unformatted by the previous pass (`client_test.go`, `deviceio.go`, `deviceio_test.go`, `discovery/discovery_test.go`, `event.go`).
- **6 unused constants**: fixed by replacing the literal string at each use site with the constant (not by deleting the constants), including two mock XML response bodies that needed `fmt.Sprintf`/`fmt.Fprintf` since the placeholder text was embedded in a raw SOAP string.
- **goconst (71 → 0)**: extracted repeated literals to named constants. Where the identical literal appeared in multiple files within the same package (`server`, `onviftesting`), consolidated into a single package-level constant referenced from every file, rather than duplicating a constant per file. Reused an already-existing constant wherever golangci-lint's message said "such constant X already exists" instead of adding a duplicate.
- **nlreturn (73 → 0)**: added a blank line before `return` in genuinely multi-line function/closure bodies. For trivial one-line inline closures, added `//nolint:nlreturn`, matching the established pattern already present in `cmd/onvif-diagnostics/main.go`. A few one-liners were returning an error from an external package call unwrapped (`return err`); wrapping those with `fmt.Errorf("Op: %w", err)` — matching sibling entries in the same table — was needed to avoid a `wrapcheck` regression once the line was touched.
- No changes to goconst/nlreturn's `.golangci.yml` exclusions — fixed mechanically as instructed, linters were not disabled or reconfigured.

## Verification

```
gofmt -l .                                    # empty
go build ./...                                # succeeds
go vet ./...                                  # clean
go test ./... (and go test -race ./...)       # all pass
golangci-lint run --timeout=5m --max-issues-per-linter=0 --max-same-issues=0 ./...
  -> 0 issues.
```

Fixes #59
