### PR TITLE
Fix Sonar Quality Gate: suppress clear-text-protocol false positive, cover PTZ converters

### DIFF
--- a/ptz_test.go
+++ b/ptz_test.go
@@ -1,0 +1,61 @@
+package onvif
+
+import "testing"
+
+func TestConvertToPTZVectorXML(t *testing.T) {
+	if got := convertToPTZVectorXML(nil); got != nil {
+		t.Errorf("convertToPTZVectorXML(nil) = %+v, want nil", got)
+	}
+
+	v := &PTZVector{
+		PanTilt: &Vector2D{X: 0.1, Y: -0.2, Space: "PanTiltSpace"},
+		Zoom:    &Vector1D{X: 0.5, Space: "ZoomSpace"},
+	}
+	got := convertToPTZVectorXML(v)
+	if got == nil {
+		t.Fatal("convertToPTZVectorXML() = nil, want non-nil")
+	}
+	if got.PanTilt == nil || got.PanTilt.X != 0.1 || got.PanTilt.Y != -0.2 || got.PanTilt.Space != "PanTiltSpace" {
+		t.Errorf("PanTilt = %+v, want {0.1 -0.2 PanTiltSpace}", got.PanTilt)
+	}
+	if got.Zoom == nil || got.Zoom.X != 0.5 || got.Zoom.Space != "ZoomSpace" {
+		t.Errorf("Zoom = %+v, want {0.5 ZoomSpace}", got.Zoom)
+	}
+
+	partial := convertToPTZVectorXML(&PTZVector{PanTilt: &Vector2D{X: 1, Y: 2}})
+	if partial.PanTilt == nil {
+		t.Error("PanTilt = nil, want non-nil")
+	}
+	if partial.Zoom != nil {
+		t.Errorf("Zoom = %+v, want nil when source Zoom is nil", partial.Zoom)
+	}
+}
+
+func TestConvertToPTZSpeedXML(t *testing.T) {
+	if got := convertToPTZSpeedXML(nil); got != nil {
+		t.Errorf("convertToPTZSpeedXML(nil) = %+v, want nil", got)
+	}
+
+	s := &PTZSpeed{
+		PanTilt: &Vector2D{X: 0.3, Y: 0.4, Space: "PanTiltSpeedSpace"},
+		Zoom:    &Vector1D{X: 0.6, Space: "ZoomSpeedSpace"},
+	}
+	got := convertToPTZSpeedXML(s)
+	if got == nil {
+		t.Fatal("convertToPTZSpeedXML() = nil, want non-nil")
+	}
+	if got.PanTilt == nil || got.PanTilt.X != 0.3 || got.PanTilt.Y != 0.4 || got.PanTilt.Space != "PanTiltSpeedSpace" {
+		t.Errorf("PanTilt = %+v, want {0.3 0.4 PanTiltSpeedSpace}", got.PanTilt)
+	}
+	if got.Zoom == nil || got.Zoom.X != 0.6 || got.Zoom.Space != "ZoomSpeedSpace" {
+		t.Errorf("Zoom = %+v, want {0.6 ZoomSpeedSpace}", got.Zoom)
+	}
+
+	partial := convertToPTZSpeedXML(&PTZSpeed{Zoom: &Vector1D{X: 9}})
+	if partial.Zoom == nil {
+		t.Error("Zoom = nil, want non-nil")
+	}
+	if partial.PanTilt != nil {
+		t.Errorf("PanTilt = %+v, want nil when source PanTilt is nil", partial.PanTilt)
+	}
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -32,7 +32,7 @@ sonar.cpd.exclusions=**/*_test.go,**/testdata/**
 sonar.security.hotspots.exclusions=**/*_test.go,**/testing/**,**/testdata/**,**/.github/**,**/examples/**,**/cmd/**
 
 # Issue exclusions for specific rules
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14
 
 # Ignore security issues in test files
 sonar.issue.ignore.multicriteria.e1.ruleKey=go:S5042
@@ -81,3 +81,9 @@ sonar.issue.ignore.multicriteria.e12.resourceKey=cmd/onvif-cli/main.go
 # Ignore hardcoded IP addresses in all Go files under examples
 sonar.issue.ignore.multicriteria.e13.ruleKey=go:S1313
 sonar.issue.ignore.multicriteria.e13.resourceKey=examples/**/*.go
+
+# ONVIF cameras are addressed over plain HTTP by protocol convention (every
+# endpoint in this repo is http://camera-ip/onvif/...); this script only
+# builds the diagnostic command line, it doesn't transmit credentials.
+sonar.issue.ignore.multicriteria.e14.ruleKey=shell:S5332
+sonar.issue.ignore.multicriteria.e14.resourceKey=collect-camera-data.sh


### PR DESCRIPTION
## Summary
- Suppress `shell:S5332` (clear-text protocol) on `collect-camera-data.sh`'s `ENDPOINT` variable — ONVIF cameras are addressed over plain HTTP by protocol convention throughout this repo; the script only builds a diagnostic command line, it doesn't transmit credentials. Same pattern as the existing false-positive suppressions in `sonar-project.properties`.
- Add real unit tests for `convertToPTZVectorXML`/`convertToPTZSpeedXML`, the only fully-uncovered new code in `ptz.go` per Sonar's new-code coverage metric.

## Context
Part of getting the SonarCloud Quality Gate green now that CI-based analysis is actually running (see #59/Sonar debt work). This closes 2 of 2 remaining `new_security_rating` vulnerabilities and the small `ptz.go` coverage gap. The larger remaining gap (`media.go`, ~33 untested Get/Set configuration methods) is being handled separately.

## Test plan
- [x] `go build ./...`
- [x] `go test -run TestConvertToPTZ -v .` passes
- [x] `gofmt -l ptz_test.go` clean