### PR TITLE
feat: add typed system date and time response (fixes #61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - Deprecate `GetSystemDateAndTime` and `FixedGetSystemDateAndTime` in favor of `GetSystemDateAndTimeTyped`.
 
+### Notes
+- **Behavior change:** When a device response omits the `SystemDateAndTime` element entirely, `GetSystemDateAndTimeTyped` now returns an error. Previously, `FixedGetSystemDateAndTime` returned a zero-value struct with no error in this case.
+
 ## [1.1.3] - 2025-11-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `GetSystemDateAndTimeTyped` for inspecting typed clock, timezone, and optional timestamp data without breaking existing callers.
+
+### Deprecated
+- Deprecate `GetSystemDateAndTime` and `FixedGetSystemDateAndTime` in favor of `GetSystemDateAndTimeTyped`.
+
 ## [1.1.3] - 2025-11-18
 
 ### Changed

--- a/cmd/onvif-cli/main.go
+++ b/cmd/onvif-cli/main.go
@@ -511,7 +511,7 @@ func (c *CLI) getCapabilities(ctx context.Context) {
 func (c *CLI) getSystemDateTime(ctx context.Context) {
 	fmt.Println("⏳ Getting system date and time...")
 
-	dateTime, err := c.client.GetSystemDateAndTime(ctx)
+	dateTime, err := c.client.GetSystemDateAndTimeTyped(ctx)
 	if err != nil {
 		fmt.Printf("❌ Error: %v\n", err)
 

--- a/cmd/onvif-diagnostics/main.go
+++ b/cmd/onvif-diagnostics/main.go
@@ -436,7 +436,7 @@ func testGetSystemDateTime(ctx context.Context, client *onvif.Client, report *Ca
 	start := time.Now()
 	result := &SystemDateTimeResult{}
 
-	dateTime, err := client.GetSystemDateAndTime(ctx)
+	dateTime, err := client.GetSystemDateAndTimeTyped(ctx)
 	result.ResponseTime = time.Since(start).String()
 
 	if err != nil {

--- a/device.go
+++ b/device.go
@@ -289,11 +289,11 @@ func (c *Client) GetSystemDateAndTimeTyped(ctx context.Context) (*SystemDateTime
 	soapClient := soap.NewClient(c.httpClient, username, password)
 
 	if err := soapClient.Call(ctx, c.endpoint, "", req, &resp); err != nil {
-		return nil, fmt.Errorf("GetSystemDateAndTime failed: %w", err)
+		return nil, fmt.Errorf("GetSystemDateAndTimeTyped failed: %w", err)
 	}
 
 	if resp.SystemDateAndTime == nil {
-		return nil, fmt.Errorf("GetSystemDateAndTime failed: %w: missing SystemDateAndTime", ErrInvalidResponse)
+		return nil, fmt.Errorf("GetSystemDateAndTimeTyped failed: %w: missing SystemDateAndTime", ErrInvalidResponse)
 	}
 
 	return resp.SystemDateAndTime, nil

--- a/device.go
+++ b/device.go
@@ -261,17 +261,29 @@ func (c *Client) SystemReboot(ctx context.Context) (string, error) {
 }
 
 // GetSystemDateAndTime retrieves the device's system date and time.
+//
+// Deprecated: Use GetSystemDateAndTimeTyped, which exposes the response as a
+// SystemDateTime instead of interface{}.
 func (c *Client) GetSystemDateAndTime(ctx context.Context) (interface{}, error) {
+	return c.GetSystemDateAndTimeTyped(ctx)
+}
+
+// GetSystemDateAndTimeTyped retrieves the device's system date and time.
+func (c *Client) GetSystemDateAndTimeTyped(ctx context.Context) (*SystemDateTime, error) {
 	type GetSystemDateAndTime struct {
 		XMLName xml.Name `xml:"tds:GetSystemDateAndTime"`
 		Xmlns   string   `xml:"xmlns:tds,attr"`
+	}
+	type GetSystemDateAndTimeResponse struct {
+		XMLName           xml.Name        `xml:"GetSystemDateAndTimeResponse"`
+		SystemDateAndTime *SystemDateTime `xml:"SystemDateAndTime"`
 	}
 
 	req := GetSystemDateAndTime{
 		Xmlns: deviceNamespace,
 	}
 
-	var resp interface{}
+	var resp GetSystemDateAndTimeResponse
 
 	username, password := c.GetCredentials()
 	soapClient := soap.NewClient(c.httpClient, username, password)
@@ -280,7 +292,11 @@ func (c *Client) GetSystemDateAndTime(ctx context.Context) (interface{}, error) 
 		return nil, fmt.Errorf("GetSystemDateAndTime failed: %w", err)
 	}
 
-	return resp, nil
+	if resp.SystemDateAndTime == nil {
+		return nil, fmt.Errorf("GetSystemDateAndTime failed: %w: missing SystemDateAndTime", ErrInvalidResponse)
+	}
+
+	return resp.SystemDateAndTime, nil
 }
 
 // GetHostname retrieves the device's hostname.

--- a/device_extended.go
+++ b/device_extended.go
@@ -124,91 +124,10 @@ func (c *Client) SetHostnameFromDHCP(ctx context.Context, fromDHCP bool) (bool, 
 }
 
 // FixedGetSystemDateAndTime retrieves the device's system date and time with proper typing.
+//
+// Deprecated: Use GetSystemDateAndTimeTyped.
 func (c *Client) FixedGetSystemDateAndTime(ctx context.Context) (*SystemDateTime, error) {
-	type GetSystemDateAndTime struct {
-		XMLName xml.Name `xml:"tds:GetSystemDateAndTime"`
-		Xmlns   string   `xml:"xmlns:tds,attr"`
-	}
-
-	type GetSystemDateAndTimeResponse struct {
-		XMLName           xml.Name `xml:"GetSystemDateAndTimeResponse"`
-		SystemDateAndTime struct {
-			DateTimeType    string `xml:"DateTimeType"`
-			DaylightSavings bool   `xml:"DaylightSavings"`
-			TimeZone        struct {
-				TZ string `xml:"TZ"`
-			} `xml:"TimeZone"`
-			UTCDateTime struct {
-				Time struct {
-					Hour   int `xml:"Hour"`
-					Minute int `xml:"Minute"`
-					Second int `xml:"Second"`
-				} `xml:"Time"`
-				Date struct {
-					Year  int `xml:"Year"`
-					Month int `xml:"Month"`
-					Day   int `xml:"Day"`
-				} `xml:"Date"`
-			} `xml:"UTCDateTime"`
-			LocalDateTime struct {
-				Time struct {
-					Hour   int `xml:"Hour"`
-					Minute int `xml:"Minute"`
-					Second int `xml:"Second"`
-				} `xml:"Time"`
-				Date struct {
-					Year  int `xml:"Year"`
-					Month int `xml:"Month"`
-					Day   int `xml:"Day"`
-				} `xml:"Date"`
-			} `xml:"LocalDateTime"`
-		} `xml:"SystemDateAndTime"`
-	}
-
-	req := GetSystemDateAndTime{
-		Xmlns: deviceNamespace,
-	}
-
-	var resp GetSystemDateAndTimeResponse
-
-	username, password := c.GetCredentials()
-	soapClient := soap.NewClient(c.httpClient, username, password)
-
-	if err := soapClient.Call(ctx, c.endpoint, "", req, &resp); err != nil {
-		return nil, fmt.Errorf("GetSystemDateAndTime failed: %w", err)
-	}
-
-	return &SystemDateTime{
-		DateTimeType:    SetDateTimeType(resp.SystemDateAndTime.DateTimeType),
-		DaylightSavings: resp.SystemDateAndTime.DaylightSavings,
-		TimeZone: &TimeZone{
-			TZ: resp.SystemDateAndTime.TimeZone.TZ,
-		},
-		UTCDateTime: &DateTime{
-			Time: Time{
-				Hour:   resp.SystemDateAndTime.UTCDateTime.Time.Hour,
-				Minute: resp.SystemDateAndTime.UTCDateTime.Time.Minute,
-				Second: resp.SystemDateAndTime.UTCDateTime.Time.Second,
-			},
-			Date: Date{
-				Year:  resp.SystemDateAndTime.UTCDateTime.Date.Year,
-				Month: resp.SystemDateAndTime.UTCDateTime.Date.Month,
-				Day:   resp.SystemDateAndTime.UTCDateTime.Date.Day,
-			},
-		},
-		LocalDateTime: &DateTime{
-			Time: Time{
-				Hour:   resp.SystemDateAndTime.LocalDateTime.Time.Hour,
-				Minute: resp.SystemDateAndTime.LocalDateTime.Time.Minute,
-				Second: resp.SystemDateAndTime.LocalDateTime.Time.Second,
-			},
-			Date: Date{
-				Year:  resp.SystemDateAndTime.LocalDateTime.Date.Year,
-				Month: resp.SystemDateAndTime.LocalDateTime.Date.Month,
-				Day:   resp.SystemDateAndTime.LocalDateTime.Date.Day,
-			},
-		},
-	}, nil
+	return c.GetSystemDateAndTimeTyped(ctx)
 }
 
 // SetSystemDateAndTime sets the device system date and time.

--- a/device_test.go
+++ b/device_test.go
@@ -3,8 +3,10 @@ package onvif
 import (
 	"context"
 	"encoding/xml"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 )
 
@@ -126,6 +128,201 @@ func TestGetCapabilities(t *testing.T) {
 	if capabilities.Device == nil || capabilities.Device.XAddr == "" {
 		t.Error("Expected Device capabilities with XAddr")
 	}
+}
+
+func TestGetSystemDateAndTimeTyped(t *testing.T) {
+	const (
+		systemDateAndTimeStart = `<tds:SystemDateAndTime xmlns:tt="http://www.onvif.org/ver10/schema">
+			<tt:DateTimeType>NTP</tt:DateTimeType>
+			<tt:DaylightSavings>true</tt:DaylightSavings>`
+		timeZoneXML    = `<tt:TimeZone><tt:TZ>CST-8</tt:TZ></tt:TimeZone>`
+		utcDateTimeXML = `<tt:UTCDateTime>
+			<tt:Time><tt:Hour>8</tt:Hour><tt:Minute>15</tt:Minute><tt:Second>30</tt:Second></tt:Time>
+			<tt:Date><tt:Year>2026</tt:Year><tt:Month>8</tt:Month><tt:Day>31</tt:Day></tt:Date>
+		</tt:UTCDateTime>`
+		localDateTimeXML = `<tt:LocalDateTime>
+			<tt:Time><tt:Hour>16</tt:Hour><tt:Minute>15</tt:Minute><tt:Second>30</tt:Second></tt:Time>
+			<tt:Date><tt:Year>2026</tt:Year><tt:Month>8</tt:Month><tt:Day>31</tt:Day></tt:Date>
+		</tt:LocalDateTime>`
+		systemDateAndTimeEnd = `</tds:SystemDateAndTime>`
+	)
+
+	timeZone := &TimeZone{TZ: "CST-8"}
+	utcDateTime := &DateTime{
+		Time: Time{Hour: 8, Minute: 15, Second: 30},
+		Date: Date{Year: 2026, Month: 8, Day: 31},
+	}
+	localDateTime := &DateTime{
+		Time: Time{Hour: 16, Minute: 15, Second: 30},
+		Date: Date{Year: 2026, Month: 8, Day: 31},
+	}
+
+	tests := []struct {
+		name               string
+		includeTimeZone    bool
+		includeUTC         bool
+		includeLocal       bool
+		omitSystemDateTime bool
+	}{
+		{
+			name:            "all optional fields present",
+			includeTimeZone: true,
+			includeUTC:      true,
+			includeLocal:    true,
+		},
+		{
+			name:         "timezone omitted",
+			includeUTC:   true,
+			includeLocal: true,
+		},
+		{
+			name:            "UTC date and time omitted",
+			includeTimeZone: true,
+			includeLocal:    true,
+		},
+		{
+			name:            "local date and time omitted",
+			includeTimeZone: true,
+			includeUTC:      true,
+		},
+		{
+			name:               "system date and time omitted",
+			omitSystemDateTime: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			responseContent := ""
+			if !tt.omitSystemDateTime {
+				responseContent = systemDateAndTimeStart
+				if tt.includeTimeZone {
+					responseContent += timeZoneXML
+				}
+				if tt.includeUTC {
+					responseContent += utcDateTimeXML
+				}
+				if tt.includeLocal {
+					responseContent += localDateTimeXML
+				}
+				responseContent += systemDateAndTimeEnd
+			}
+
+			server := newSystemDateAndTimeServer(t, responseContent)
+			defer server.Close()
+
+			client, err := NewClient(server.URL)
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			got, err := client.GetSystemDateAndTimeTyped(context.Background())
+			if tt.omitSystemDateTime {
+				if err == nil {
+					t.Fatal("GetSystemDateAndTimeTyped() error = nil, want an error")
+				}
+				if !errors.Is(err, ErrInvalidResponse) {
+					t.Errorf("GetSystemDateAndTimeTyped() error = %v, want ErrInvalidResponse", err)
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetSystemDateAndTimeTyped() error = %v", err)
+			}
+
+			want := &SystemDateTime{
+				DateTimeType:    SetDateTimeNTP,
+				DaylightSavings: true,
+			}
+			if tt.includeTimeZone {
+				want.TimeZone = timeZone
+			}
+			if tt.includeUTC {
+				want.UTCDateTime = utcDateTime
+			}
+			if tt.includeLocal {
+				want.LocalDateTime = localDateTime
+			}
+
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("GetSystemDateAndTimeTyped() = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestGetSystemDateAndTimeCompatibilityMethods(t *testing.T) {
+	const responseContent = `<tds:SystemDateAndTime xmlns:tt="http://www.onvif.org/ver10/schema">
+		<tt:DateTimeType>Manual</tt:DateTimeType>
+		<tt:DaylightSavings>false</tt:DaylightSavings>
+		<tt:TimeZone><tt:TZ>UTC0</tt:TZ></tt:TimeZone>
+	</tds:SystemDateAndTime>`
+
+	server := newSystemDateAndTimeServer(t, responseContent)
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	untyped, err := client.GetSystemDateAndTime(context.Background())
+	if err != nil {
+		t.Fatalf("GetSystemDateAndTime() error = %v", err)
+	}
+	untypedDateTime, ok := untyped.(*SystemDateTime)
+	if !ok {
+		t.Fatalf("GetSystemDateAndTime() returned %T, want *SystemDateTime", untyped)
+	}
+
+	fixedDateTime, err := client.FixedGetSystemDateAndTime(context.Background())
+	if err != nil {
+		t.Fatalf("FixedGetSystemDateAndTime() error = %v", err)
+	}
+
+	want := &SystemDateTime{
+		DateTimeType: SetDateTimeManual,
+		TimeZone:     &TimeZone{TZ: "UTC0"},
+	}
+	if !reflect.DeepEqual(untypedDateTime, want) {
+		t.Errorf("GetSystemDateAndTime() = %#v, want %#v", untypedDateTime, want)
+	}
+	if !reflect.DeepEqual(fixedDateTime, want) {
+		t.Errorf("FixedGetSystemDateAndTime() = %#v, want %#v", fixedDateTime, want)
+	}
+}
+
+func newSystemDateAndTimeServer(t *testing.T, responseContent string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var envelope struct {
+			Body struct {
+				GetSystemDateAndTime struct {
+					XMLName xml.Name `xml:"GetSystemDateAndTime"`
+				} `xml:"GetSystemDateAndTime"`
+			} `xml:"Body"`
+		}
+		if err := xml.NewDecoder(r.Body).Decode(&envelope); err != nil {
+			t.Errorf("Failed to decode request: %v", err)
+		}
+		if envelope.Body.GetSystemDateAndTime.XMLName.Local != "GetSystemDateAndTime" {
+			t.Errorf("Request operation = %q, want GetSystemDateAndTime", envelope.Body.GetSystemDateAndTime.XMLName.Local)
+		}
+
+		response := `<?xml version="1.0" encoding="UTF-8"?>
+		<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+			<s:Body>
+				<tds:GetSystemDateAndTimeResponse xmlns:tds="http://www.onvif.org/ver10/device/wsdl">` +
+			responseContent +
+			`</tds:GetSystemDateAndTimeResponse>
+			</s:Body>
+		</s:Envelope>`
+		w.Header().Set("Content-Type", "application/soap+xml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(response))
+	}))
 }
 
 func TestGetHostname(t *testing.T) {

--- a/examples/comprehensive-test/main.go
+++ b/examples/comprehensive-test/main.go
@@ -47,7 +47,7 @@ func main() {
 
 	// Test 2: Get System Date and Time
 	fmt.Println("=== Test 2: GetSystemDateAndTime ===")
-	dateTime, err := client.GetSystemDateAndTime(ctx)
+	dateTime, err := client.GetSystemDateAndTimeTyped(ctx)
 	if err != nil {
 		log.Printf("ERROR: %v\n", err)
 	} else {

--- a/examples/test-real-camera-all/main.go
+++ b/examples/test-real-camera-all/main.go
@@ -209,7 +209,7 @@ func testDeviceOperations(ctx context.Context, client *onvif.Client, report *Cam
 
 	// System operations
 	testOperation("GetSystemDateAndTime", func() (interface{}, error) {
-		return client.GetSystemDateAndTime(ctx)
+		return client.GetSystemDateAndTimeTyped(ctx)
 	})
 	testOperation("GetHostname", func() (interface{}, error) {
 		return client.GetHostname(ctx)


### PR DESCRIPTION
Closes #61. Adds `GetSystemDateAndTimeTyped(ctx) (*SystemDateTime, error)`, which correctly unmarshals the ONVIF SOAP response into the existing public type.

The previous `GetSystemDateAndTime` silently returned nil (the interface{} unmarshal bug from #61). `FixedGetSystemDateAndTime` had a latent bug where optional nested fields were always non-nil even when the server omitted them. Both are now deprecated shims delegating to the new method.

**Changes:**
- New `GetSystemDateAndTimeTyped` in `device.go`
- `GetSystemDateAndTime` and `FixedGetSystemDateAndTime` deprecated as one-line shims
- ~85 lines of hand-rolled XML parsing deleted
- All in-repo call sites updated to the new method
- CHANGELOG updated

**Behavior note:** When a device response omits `SystemDateAndTime` entirely, `GetSystemDateAndTimeTyped` returns an error. Previously `FixedGetSystemDateAndTime` returned a zero-value struct with no error.

Co-authored-by: TLNing260310 <TLNing260310@users.noreply.github.com>