### PR TITLE
fix(server): correct SOAP request decoding, PTZ/imaging races, and auth hardening

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -9,14 +9,13 @@ import (
 	"net"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
 	// WS-Discovery multicast address.
 	multicastAddr = "239.255.255.250:3702"
-	// UUID generation constants.
-	uuidMod1000  = 1000
-	uuidMod10000 = 10000
 
 	// WS-Discovery probe message.
 	probeTemplate = `<?xml version="1.0" encoding="UTF-8"?>
@@ -225,18 +224,9 @@ func deviceMapToSlice(m map[string]*Device) []*Device {
 	return devices
 }
 
-// generateUUID generates a simple UUID (not cryptographically secure).
+// generateUUID generates an RFC 4122 UUID for the WS-Discovery MessageID.
 func generateUUID() string {
-	now := time.Now()
-	nanos := now.UnixNano()
-	secs := now.Unix()
-
-	return fmt.Sprintf("%d-%d-%d-%d-%d",
-		nanos,
-		secs,
-		nanos%uuidMod1000,
-		secs%uuidMod1000,
-		nanos%uuidMod10000)
+	return uuid.NewString()
 }
 
 // resolveNetworkInterface resolves a network interface by name or IP address.

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -443,6 +445,21 @@ func TestDiscover_BackwardCompatibility(t *testing.T) {
 	}
 
 	t.Logf("Backward compat: found %d devices", len(devices))
+}
+
+// TestGenerateUUID is a regression test for generateUUID producing a
+// wall-clock-derived, non-RFC-4122 string (e.g. "1699999999-..."). Every
+// call must now be a real, unique, parseable UUID.
+func TestGenerateUUID(t *testing.T) {
+	first := generateUUID()
+	if _, err := uuid.Parse(first); err != nil {
+		t.Fatalf("generateUUID() = %q is not a valid UUID: %v", first, err)
+	}
+
+	second := generateUUID()
+	if first == second {
+		t.Errorf("expected two calls to generateUUID() to differ, both got %q", first)
+	}
 }
 
 func BenchmarkListNetworkInterfaces(b *testing.B) {

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,14 @@ module github.com/0x524a/onvif-go
 
 go 1.25.0
 
-require github.com/0x524A/rtspeek v0.0.1
+require (
+	github.com/0x524A/rtspeek v0.0.1
+	github.com/google/uuid v1.6.0
+)
 
 require (
 	github.com/bluenviron/gortsplib/v4 v4.16.2 // indirect
 	github.com/bluenviron/mediacommon/v2 v2.9.3 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/pion/logging v0.2.4 // indirect

--- a/server/imaging.go
+++ b/server/imaging.go
@@ -3,7 +3,6 @@ package server
 import (
 	"encoding/xml"
 	"fmt"
-	"sync"
 )
 
 // Imaging service SOAP message types
@@ -204,8 +203,6 @@ type MoveResponse struct {
 
 // Imaging service handlers
 
-var imagingMutex sync.RWMutex
-
 // HandleGetImagingSettings handles GetImagingSettings request.
 func (s *Server) HandleGetImagingSettings(body interface{}) (interface{}, error) {
 	var req GetImagingSettingsRequest
@@ -214,8 +211,8 @@ func (s *Server) HandleGetImagingSettings(body interface{}) (interface{}, error)
 	}
 
 	// Get imaging state
-	imagingMutex.RLock()
-	defer imagingMutex.RUnlock()
+	s.imagingMu.RLock()
+	defer s.imagingMu.RUnlock()
 
 	state, ok := s.imagingState[req.VideoSourceToken]
 	if !ok {
@@ -275,8 +272,8 @@ func (s *Server) HandleSetImagingSettings(body interface{}) (interface{}, error)
 	}
 
 	// Get imaging state
-	imagingMutex.Lock()
-	defer imagingMutex.Unlock()
+	s.imagingMu.Lock()
+	defer s.imagingMu.Unlock()
 
 	state, ok := s.imagingState[req.VideoSourceToken]
 	if !ok {
@@ -346,6 +343,18 @@ func (s *Server) HandleSetImagingSettings(body interface{}) (interface{}, error)
 
 // HandleGetOptions handles GetOptions request.
 func (s *Server) HandleGetOptions(body interface{}) (interface{}, error) {
+	var req GetOptionsRequest
+	if err := unmarshalBody(body, &req); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
+	s.imagingMu.RLock()
+	_, ok := s.imagingState[req.VideoSourceToken]
+	s.imagingMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrVideoSourceNotFound, req.VideoSourceToken)
+	}
+
 	// Return available imaging options/capabilities
 	const maxImagingValue = 100   // Maximum imaging parameter value
 	const maxExposureTime = 10000 // Maximum exposure time in microseconds
@@ -399,8 +408,8 @@ func (s *Server) HandleMove(body interface{}) (interface{}, error) {
 	}
 
 	// Get imaging state
-	imagingMutex.Lock()
-	defer imagingMutex.Unlock()
+	s.imagingMu.Lock()
+	defer s.imagingMu.Unlock()
 
 	state, ok := s.imagingState[req.VideoSourceToken]
 	if !ok {

--- a/server/imaging_test.go
+++ b/server/imaging_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/xml"
+	"errors"
 	"testing"
 )
 
@@ -99,11 +100,7 @@ func TestHandleGetOptions(t *testing.T) {
 	server, _ := New(config)
 	videoSourceToken := config.Profiles[0].VideoSource.Token
 
-	type getOptionsRequest struct {
-		VideoSourceToken string `xml:"VideoSourceToken"`
-	}
-
-	req := getOptionsRequest{VideoSourceToken: videoSourceToken}
+	req := GetOptionsRequest{VideoSourceToken: videoSourceToken}
 	reqData, _ := xml.Marshal(req)
 
 	resp, err := server.HandleGetOptions(reqData)
@@ -128,6 +125,24 @@ func TestHandleGetOptions(t *testing.T) {
 	}
 	if optionsResp.ImagingOptions.Contrast == nil {
 		t.Error("Contrast options is nil")
+	}
+}
+
+// TestHandleGetOptionsUnknownVideoSource is a regression test: GetOptions
+// used to ignore its argument entirely and return the same static
+// capabilities regardless of VideoSourceToken, including for tokens that
+// don't exist. It must now validate the token like its sibling
+// GetImagingSettings does.
+func TestHandleGetOptionsUnknownVideoSource(t *testing.T) {
+	config := createTestConfig()
+	server, _ := New(config)
+
+	req := GetOptionsRequest{VideoSourceToken: "does-not-exist"}
+	reqData, _ := xml.Marshal(req)
+
+	_, err := server.HandleGetOptions(reqData)
+	if !errors.Is(err, ErrVideoSourceNotFound) {
+		t.Errorf("expected ErrVideoSourceNotFound, got %v", err)
 	}
 }
 
@@ -480,9 +495,7 @@ func TestHandleGetOptionsDetails(t *testing.T) {
 	server, _ := New(config)
 	videoSourceToken := config.Profiles[0].VideoSource.Token
 
-	resp, err := server.HandleGetOptions(struct {
-		VideoSourceToken string `xml:"VideoSourceToken"`
-	}{VideoSourceToken: videoSourceToken})
+	resp, err := server.HandleGetOptions(GetOptionsRequest{VideoSourceToken: videoSourceToken})
 
 	if err != nil {
 		t.Fatalf("HandleGetOptions error: %v", err)

--- a/server/imaging_test.go
+++ b/server/imaging_test.go
@@ -137,7 +137,7 @@ func TestHandleGetOptionsUnknownVideoSource(t *testing.T) {
 	config := createTestConfig()
 	server, _ := New(config)
 
-	req := GetOptionsRequest{VideoSourceToken: "does-not-exist"}
+	req := GetOptionsRequest{VideoSourceToken: testInvalidToken}
 	reqData, _ := xml.Marshal(req)
 
 	_, err := server.HandleGetOptions(reqData)

--- a/server/integration_test.go
+++ b/server/integration_test.go
@@ -1,0 +1,185 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	internalsoap "github.com/0x524a/onvif-go/internal/soap"
+)
+
+// TestServeHTTPEndToEndContinuousMove is a regression test for a bug where
+// every parameterized server operation always received a nil request body
+// (originsoap.Body.Content was interface{}, which encoding/xml cannot
+// populate), so every such operation always failed with a SOAP Fault
+// regardless of what a client sent. Prior to this test, no _test.go
+// anywhere drove a real HTTP request through the real wire path
+// (soap.Handler.ServeHTTP) against a real *Server - every existing test
+// called Handle* functions directly with bytes the broken layer never
+// actually produces, which is why the bug was invisible.
+//
+// This test builds a real *Server, wires it up exactly the way Start()
+// does, and uses the real internal/soap.Client (the same client the public
+// onvif.Client uses against real cameras) to send a real, WS-Security
+// authenticated ContinuousMove request over real HTTP. It then asserts
+// server-side state actually changed as a result.
+func TestServeHTTPEndToEndContinuousMove(t *testing.T) {
+	config := createTestConfig()
+
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	srv.registerPTZService(mux)
+
+	testServer := httptest.NewServer(mux)
+	defer testServer.Close()
+
+	profileToken := config.Profiles[0].Token
+	soapClient := internalsoap.NewClient(testServer.Client(), config.Username, config.Password)
+
+	req := ContinuousMoveRequest{
+		ProfileToken: profileToken,
+		Velocity: PTZVector{
+			PanTilt: &Vector2D{X: 0.5, Y: 0.2},
+		},
+	}
+
+	endpoint := testServer.URL + config.BasePath + "/ptz_service"
+	if err := soapClient.Call(context.Background(), endpoint, "", req, nil); err != nil {
+		t.Fatalf("ContinuousMove over the real wire path failed: %v", err)
+	}
+
+	state, ok := srv.GetPTZState(profileToken)
+	if !ok {
+		t.Fatalf("expected PTZ state for profile %q", profileToken)
+	}
+	if !state.Moving || !state.PanMoving || !state.TiltMoving {
+		t.Errorf("expected PTZ state to reflect the move sent over HTTP, got %+v", state)
+	}
+}
+
+// TestUpdateStreamURIRace exercises UpdateStreamURI concurrently with reads
+// via GetStreamConfig and HandleGetStreamURI, catching the data race that
+// existed before streamsMu was added. Run with -race.
+func TestUpdateStreamURIRace(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	profileToken := config.Profiles[0].Token
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			_ = srv.UpdateStreamURI(profileToken, "rtsp://example.invalid/stream")
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = srv.GetStreamConfig(profileToken)
+		}()
+		go func() {
+			defer wg.Done()
+			type getStreamURIRequest struct {
+				ProfileToken string `xml:"ProfileToken"`
+			}
+			_, _ = srv.HandleGetStreamURI(getStreamURIRequest{ProfileToken: profileToken})
+		}()
+	}
+	wg.Wait()
+}
+
+// TestPTZSettleTimerCancelledOnRepeatedMove is a regression test for the
+// PTZ handlers spawning an untracked, uncancellable goroutine per move to
+// clear the Moving flags after a fixed delay: a second move for the same
+// profile before the first one settled left two goroutines racing to clear
+// the same state, so the first move's goroutine could clobber the second
+// move's Moving flag out from under it.
+//
+// Timeline: call 1 schedules a settle for t=500ms. At t=300ms, call 2
+// happens - this must cancel call 1's pending timer and schedule its own
+// for t=800ms. The check at t=600ms falls after call 1's original delay
+// but well before call 2's, so if call 1's timer weren't canceled it
+// would have already fired and cleared Moving by then.
+func TestPTZSettleTimerCancelledOnRepeatedMove(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	profileToken := config.Profiles[0].Token
+
+	move := AbsoluteMoveRequest{
+		ProfileToken: profileToken,
+		Position:     PTZVector{PanTilt: &Vector2D{X: 0.5, Y: 0.2}},
+	}
+
+	if _, err := srv.HandleAbsoluteMove(move); err != nil {
+		t.Fatalf("first HandleAbsoluteMove() error = %v", err)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+
+	if _, err := srv.HandleAbsoluteMove(move); err != nil {
+		t.Fatalf("second HandleAbsoluteMove() error = %v", err)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+
+	state, ok := srv.GetPTZState(profileToken)
+	if !ok {
+		t.Fatalf("expected PTZ state for profile %q", profileToken)
+	}
+	if !state.Moving {
+		t.Errorf("Moving was cleared by a stale settle timer from the first move; " +
+			"the second move's own timer should still be pending")
+	}
+}
+
+// TestPTZStopCancelsSettleTimer is a regression test proving Stop cancels
+// any pending settle timer immediately (state.settleTimer is nilled out),
+// rather than leaving it live to fire later and clear whatever a
+// subsequent move sets. Checked directly on the PTZState field rather than
+// via a timing-based wait, since a stale timer clearing already-false
+// flags is not observable through Moving alone.
+func TestPTZStopCancelsSettleTimer(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	profileToken := config.Profiles[0].Token
+
+	move := AbsoluteMoveRequest{
+		ProfileToken: profileToken,
+		Position:     PTZVector{PanTilt: &Vector2D{X: 0.5, Y: 0.2}},
+	}
+	if _, err := srv.HandleAbsoluteMove(move); err != nil {
+		t.Fatalf("HandleAbsoluteMove() error = %v", err)
+	}
+
+	state, ok := srv.GetPTZState(profileToken)
+	if !ok {
+		t.Fatalf("expected PTZ state for profile %q", profileToken)
+	}
+	if state.settleTimer == nil {
+		t.Fatalf("expected a pending settle timer after AbsoluteMove")
+	}
+
+	if _, err := srv.HandleStop(StopRequest{ProfileToken: profileToken, PanTilt: true, Zoom: true}); err != nil {
+		t.Fatalf("HandleStop() error = %v", err)
+	}
+
+	if state.settleTimer != nil {
+		t.Errorf("expected Stop to cancel and clear the pending settle timer, it's still set")
+	}
+}

--- a/server/integration_test.go
+++ b/server/integration_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -181,5 +182,140 @@ func TestPTZStopCancelsSettleTimer(t *testing.T) {
 
 	if state.settleTimer != nil {
 		t.Errorf("expected Stop to cancel and clear the pending settle timer, it's still set")
+	}
+}
+
+// TestHandleRelativeMove exercises HandleRelativeMove directly with a real
+// typed request (unlike the disabled/skipped tests elsewhere in this
+// package that hand-build namespace-less XML and silently never reach
+// their assertions, this actually runs).
+func TestHandleRelativeMove(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	profileToken := config.Profiles[0].Token
+
+	req := RelativeMoveRequest{
+		ProfileToken: profileToken,
+		Translation: PTZVector{
+			PanTilt: &Vector2D{X: 10, Y: 5},
+			Zoom:    &Vector1D{X: 0.1},
+		},
+	}
+
+	resp, err := srv.HandleRelativeMove(req)
+	if err != nil {
+		t.Fatalf("HandleRelativeMove() error = %v", err)
+	}
+	if _, ok := resp.(*RelativeMoveResponse); !ok {
+		t.Fatalf("expected *RelativeMoveResponse, got %T", resp)
+	}
+
+	state, ok := srv.GetPTZState(profileToken)
+	if !ok {
+		t.Fatalf("expected PTZ state for profile %q", profileToken)
+	}
+	if !state.Moving {
+		t.Errorf("expected Moving to be true after RelativeMove")
+	}
+	if state.Position.Pan != 10 || state.Position.Tilt != 5 || state.Position.Zoom != 0.1 {
+		t.Errorf("expected position to reflect the translation, got %+v", state.Position)
+	}
+
+	if _, err := srv.HandleRelativeMove(RelativeMoveRequest{ProfileToken: testInvalidToken}); !errors.Is(err, ErrPTZNotSupported) {
+		t.Errorf("expected ErrPTZNotSupported for an unknown profile, got %v", err)
+	}
+}
+
+// TestHandleMove exercises the imaging HandleMove (focus) handler directly
+// with a real typed request - the existing _DisabledTestHandleMove in
+// imaging_test.go is disabled for the same namespace-mismatch reason as
+// TestHandleGotoPreset above.
+func TestHandleMove(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	videoSourceToken := config.Profiles[0].VideoSource.Token
+
+	resp, err := srv.HandleMove(MoveRequest{
+		VideoSourceToken: videoSourceToken,
+		Focus:            &FocusMove{Absolute: &AbsoluteFocus{Position: 0.75}},
+	})
+	if err != nil {
+		t.Fatalf("HandleMove() error = %v", err)
+	}
+	if _, ok := resp.(*MoveResponse); !ok {
+		t.Fatalf("expected *MoveResponse, got %T", resp)
+	}
+
+	state, ok := srv.GetImagingState(videoSourceToken)
+	if !ok {
+		t.Fatalf("expected imaging state for video source %q", videoSourceToken)
+	}
+	if state.Focus.CurrentPos != 0.75 {
+		t.Errorf("expected Focus.CurrentPos to be 0.75, got %v", state.Focus.CurrentPos)
+	}
+
+	if _, err := srv.HandleMove(MoveRequest{VideoSourceToken: testInvalidToken}); !errors.Is(err, ErrVideoSourceNotFound) {
+		t.Errorf("expected ErrVideoSourceNotFound for an unknown video source, got %v", err)
+	}
+}
+
+// TestHandleGetStreamURIUnknownProfile covers the not-found path of
+// HandleGetStreamURI, which the new streamsMu-guarded early return
+// (server/media.go) needs exercised.
+func TestHandleGetStreamURIUnknownProfile(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	type getStreamURIRequest struct {
+		ProfileToken string `xml:"ProfileToken"`
+	}
+	_, err = srv.HandleGetStreamURI(getStreamURIRequest{ProfileToken: testInvalidToken})
+	if !errors.Is(err, ErrProfileNotFound) {
+		t.Errorf("expected ErrProfileNotFound, got %v", err)
+	}
+}
+
+// TestScheduleSettleFires lets a settle timer actually fire (with a short
+// custom delay, rather than waiting out the real 500ms/1s constants) and
+// verifies it clears the Moving flags - the one path none of the other PTZ
+// timer tests exercise, since they only check cancellation/replacement.
+func TestScheduleSettleFires(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	profileToken := config.Profiles[0].Token
+
+	state, ok := srv.GetPTZState(profileToken)
+	if !ok {
+		t.Fatalf("expected PTZ state for profile %q", profileToken)
+	}
+
+	srv.ptzMu.Lock()
+	state.Moving = true
+	state.PanMoving = true
+	state.TiltMoving = true
+	state.ZoomMoving = true
+	srv.scheduleSettle(state, 10*time.Millisecond)
+	srv.ptzMu.Unlock()
+
+	time.Sleep(150 * time.Millisecond)
+
+	state, ok = srv.GetPTZState(profileToken)
+	if !ok {
+		t.Fatalf("expected PTZ state for profile %q", profileToken)
+	}
+	if state.Moving || state.PanMoving || state.TiltMoving || state.ZoomMoving {
+		t.Errorf("expected the settle timer to have cleared all Moving flags, got %+v", state)
 	}
 }

--- a/server/media.go
+++ b/server/media.go
@@ -270,20 +270,26 @@ func (s *Server) HandleGetStreamURI(body interface{}) (interface{}, error) {
 	}
 
 	// Find the stream configuration for this profile
+	s.streamsMu.RLock()
 	streamCfg, ok := s.streams[req.ProfileToken]
 	if !ok {
+		s.streamsMu.RUnlock()
+
 		return nil, fmt.Errorf("%w: %s", ErrProfileNotFound, req.ProfileToken)
 	}
 
 	// Build RTSP URI
 	uri := streamCfg.StreamURI
+	rtspPath := streamCfg.RTSPPath
+	s.streamsMu.RUnlock()
+
 	if uri == "" {
 		// Default URI construction
 		host := s.config.Host
 		if host == defaultHost || host == "" {
 			host = defaultHostname
 		}
-		uri = fmt.Sprintf("rtsp://%s:8554%s", host, streamCfg.RTSPPath)
+		uri = fmt.Sprintf("rtsp://%s:8554%s", host, rtspPath)
 	}
 
 	return &GetStreamURIResponse{

--- a/server/ptz.go
+++ b/server/ptz.go
@@ -3,7 +3,6 @@ package server
 import (
 	"encoding/xml"
 	"fmt"
-	"sync"
 	"time"
 )
 
@@ -198,7 +197,11 @@ type FloatRange struct {
 
 // PTZ service handlers
 
-var ptzMutex sync.RWMutex
+// Named settle delays, replacing what used to be inline magic numbers.
+const (
+	ptzMoveSettleDelay   = 500 * time.Millisecond
+	ptzPresetSettleDelay = 1 * time.Second
+)
 
 // HandleContinuousMove handles ContinuousMove request.
 func (s *Server) HandleContinuousMove(body interface{}) (interface{}, error) {
@@ -208,8 +211,8 @@ func (s *Server) HandleContinuousMove(body interface{}) (interface{}, error) {
 	}
 
 	// Get PTZ state
-	ptzMutex.Lock()
-	defer ptzMutex.Unlock()
+	s.ptzMu.Lock()
+	defer s.ptzMu.Unlock()
 
 	state, ok := s.ptzState[req.ProfileToken]
 	if !ok {
@@ -241,8 +244,8 @@ func (s *Server) HandleAbsoluteMove(body interface{}) (interface{}, error) {
 	}
 
 	// Get PTZ state
-	ptzMutex.Lock()
-	defer ptzMutex.Unlock()
+	s.ptzMu.Lock()
+	defer s.ptzMu.Unlock()
 
 	state, ok := s.ptzState[req.ProfileToken]
 	if !ok {
@@ -267,15 +270,7 @@ func (s *Server) HandleAbsoluteMove(body interface{}) (interface{}, error) {
 
 	// In a real implementation, simulate movement over time
 	// For now, we'll stop immediately
-	go func() {
-		time.Sleep(500 * time.Millisecond) //nolint:mnd // PTZ movement delay
-		ptzMutex.Lock()
-		state.Moving = false
-		state.PanMoving = false
-		state.TiltMoving = false
-		state.ZoomMoving = false
-		ptzMutex.Unlock()
-	}()
+	s.scheduleSettle(state, ptzMoveSettleDelay)
 
 	return &AbsoluteMoveResponse{}, nil
 }
@@ -288,8 +283,8 @@ func (s *Server) HandleRelativeMove(body interface{}) (interface{}, error) {
 	}
 
 	// Get PTZ state
-	ptzMutex.Lock()
-	defer ptzMutex.Unlock()
+	s.ptzMu.Lock()
+	defer s.ptzMu.Unlock()
 
 	state, ok := s.ptzState[req.ProfileToken]
 	if !ok {
@@ -316,15 +311,7 @@ func (s *Server) HandleRelativeMove(body interface{}) (interface{}, error) {
 	state.LastUpdate = time.Now()
 
 	// Simulate movement completion
-	go func() {
-		time.Sleep(500 * time.Millisecond) //nolint:mnd // PTZ movement delay
-		ptzMutex.Lock()
-		state.Moving = false
-		state.PanMoving = false
-		state.TiltMoving = false
-		state.ZoomMoving = false
-		ptzMutex.Unlock()
-	}()
+	s.scheduleSettle(state, ptzMoveSettleDelay)
 
 	return &RelativeMoveResponse{}, nil
 }
@@ -337,12 +324,20 @@ func (s *Server) HandleStop(body interface{}) (interface{}, error) {
 	}
 
 	// Get PTZ state
-	ptzMutex.Lock()
-	defer ptzMutex.Unlock()
+	s.ptzMu.Lock()
+	defer s.ptzMu.Unlock()
 
 	state, ok := s.ptzState[req.ProfileToken]
 	if !ok {
 		return nil, fmt.Errorf("%w: %s", ErrPTZNotSupported, req.ProfileToken)
+	}
+
+	// Cancel any pending settle timer - Stop already clears the flags
+	// immediately below, so a stale timer must not fire later and
+	// overwrite whatever the next move sets.
+	if state.settleTimer != nil {
+		state.settleTimer.Stop()
+		state.settleTimer = nil
 	}
 
 	// Stop movement
@@ -373,8 +368,8 @@ func (s *Server) HandleGetStatus(body interface{}) (interface{}, error) {
 	}
 
 	// Get PTZ state
-	ptzMutex.RLock()
-	defer ptzMutex.RUnlock()
+	s.ptzMu.RLock()
+	defer s.ptzMu.RUnlock()
 
 	state, ok := s.ptzState[req.ProfileToken]
 	if !ok {
@@ -486,8 +481,8 @@ func (s *Server) HandleGotoPreset(body interface{}) (interface{}, error) {
 	}
 
 	// Get PTZ state and move to preset
-	ptzMutex.Lock()
-	defer ptzMutex.Unlock()
+	s.ptzMu.Lock()
+	defer s.ptzMu.Unlock()
 
 	state := s.ptzState[req.ProfileToken]
 	state.Position = *presetPos
@@ -498,17 +493,38 @@ func (s *Server) HandleGotoPreset(body interface{}) (interface{}, error) {
 	state.LastUpdate = time.Now()
 
 	// Simulate movement completion
-	go func() {
-		time.Sleep(1 * time.Second)
-		ptzMutex.Lock()
+	s.scheduleSettle(state, ptzPresetSettleDelay)
+
+	return &GotoPresetResponse{}, nil
+}
+
+// scheduleSettle stops any settle timer already pending for state and
+// schedules a new one that clears its Moving/PanMoving/TiltMoving/
+// ZoomMoving flags after delay. Must be called with s.ptzMu held, since it
+// mutates state.settleTimer, a field shared with other PTZ handlers.
+//
+// time.AfterFunc replaces what used to be a bare, untracked goroutine per
+// move call - the returned *Timer can be stopped, so a second move for the
+// same profile before the first one settles no longer leaves two timers
+// racing to clear the same state. Timer.Stop() never blocks, so this cannot
+// deadlock even though the callback below re-acquires s.ptzMu. Note this
+// doesn't fully eliminate the race: if the old timer's callback has already
+// fired and is itself waiting on s.ptzMu at the moment Stop() is called
+// here, Stop() is a no-op and that stale callback still runs right after
+// this handler returns, clobbering the state it just set. That window is
+// narrow and acceptable for a test simulator.
+func (s *Server) scheduleSettle(state *PTZState, delay time.Duration) {
+	if state.settleTimer != nil {
+		state.settleTimer.Stop()
+	}
+	state.settleTimer = time.AfterFunc(delay, func() {
+		s.ptzMu.Lock()
+		defer s.ptzMu.Unlock()
 		state.Moving = false
 		state.PanMoving = false
 		state.TiltMoving = false
 		state.ZoomMoving = false
-		ptzMutex.Unlock()
-	}()
-
-	return &GotoPresetResponse{}, nil
+	})
 }
 
 // Helper functions

--- a/server/ptz_test.go
+++ b/server/ptz_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/xml"
+	"errors"
 	"testing"
 	"time"
 )
@@ -44,25 +45,20 @@ func _DisabledTestHandleGetPresets(t *testing.T) {
 
 func TestHandleGotoPreset(t *testing.T) {
 	config := createTestConfig()
+	// createTestConfig doesn't define any presets by default; hand-rolled
+	// XML against HandleGetPresets used to "discover" one here, but that
+	// always failed to unmarshal against GetPresetsRequest's namespaced
+	// XMLName tag (silently skipping this test - see the real fix for
+	// that discovery step in TestHandleGotoPresetWithRealPreset). Define
+	// one directly instead.
+	presetToken := "preset1"
+	config.Profiles[0].PTZ.Presets = []Preset{
+		{Token: presetToken, Name: homePresetName, Position: PTZPosition{Pan: 1, Tilt: 2, Zoom: 0.3}},
+	}
 	server, _ := New(config)
 	profileToken := config.Profiles[0].Token
 
-	// First get available presets
-	reqXML := `<GetPresets><ProfileToken>` + profileToken + `</ProfileToken></GetPresets>`
-	presetsResp, _ := server.HandleGetPresets([]byte(reqXML))
-	presetsResp2, ok := presetsResp.(*GetPresetsResponse)
-	if !ok || presetsResp2 == nil {
-		t.Skip("Could not get presets")
-	}
-	if len(presetsResp2.Preset) == 0 {
-		t.Skip("No presets available")
-	}
-
-	presetToken := presetsResp2.Preset[0].Token
-
-	// Now go to preset
-	gotoXML := `<GotoPreset><ProfileToken>` + profileToken + `</ProfileToken><PresetToken>` + presetToken + `</PresetToken></GotoPreset>`
-	gotoResp, err := server.HandleGotoPreset([]byte(gotoXML))
+	gotoResp, err := server.HandleGotoPreset(GotoPresetRequest{ProfileToken: profileToken, PresetToken: presetToken})
 	if err != nil {
 		t.Fatalf("HandleGotoPreset() error = %v", err)
 	}
@@ -74,6 +70,10 @@ func TestHandleGotoPreset(t *testing.T) {
 
 	if gotoResp2 == nil {
 		t.Error("GotoPresetResponse is nil")
+	}
+
+	if _, err := server.HandleGotoPreset(GotoPresetRequest{ProfileToken: profileToken, PresetToken: "no-such-preset"}); !errors.Is(err, ErrPresetNotFound) {
+		t.Errorf("expected ErrPresetNotFound for an unknown preset, got %v", err)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -140,6 +140,7 @@ func (s *Server) Start(ctx context.Context) error {
 			fmt.Printf("📷 Imaging Service: http://%s%s/imaging_service\n", addr, s.config.BasePath)
 		}
 		fmt.Printf("\n🌐 Virtual Camera Profiles:\n")
+		s.streamsMu.RLock()
 		//nolint:gocritic // Range value copy is acceptable for small structs
 		for i, profile := range s.config.Profiles {
 			stream := s.streams[profile.Token]
@@ -149,6 +150,7 @@ func (s *Server) Start(ctx context.Context) error {
 				profile.VideoEncoder.Resolution.Height,
 				profile.VideoEncoder.Framerate)
 		}
+		s.streamsMu.RUnlock()
 		fmt.Printf("\n✅ Server is ready!\n\n")
 
 		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -278,6 +280,8 @@ func (s *Server) GetConfig() *Config {
 
 // GetStreamConfig returns the stream configuration for a profile.
 func (s *Server) GetStreamConfig(profileToken string) (*StreamConfig, bool) {
+	s.streamsMu.RLock()
+	defer s.streamsMu.RUnlock()
 	stream, ok := s.streams[profileToken]
 
 	return stream, ok
@@ -285,6 +289,9 @@ func (s *Server) GetStreamConfig(profileToken string) (*StreamConfig, bool) {
 
 // UpdateStreamURI updates the RTSP URI for a profile.
 func (s *Server) UpdateStreamURI(profileToken, uri string) error {
+	s.streamsMu.Lock()
+	defer s.streamsMu.Unlock()
+
 	stream, ok := s.streams[profileToken]
 	if !ok {
 		return fmt.Errorf("%w: %s", ErrProfileNotFound, profileToken)
@@ -301,8 +308,8 @@ func (s *Server) ListProfiles() []ProfileConfig {
 
 // GetPTZState returns the current PTZ state for a profile.
 func (s *Server) GetPTZState(profileToken string) (*PTZState, bool) {
-	ptzMutex.RLock()
-	defer ptzMutex.RUnlock()
+	s.ptzMu.RLock()
+	defer s.ptzMu.RUnlock()
 	state, ok := s.ptzState[profileToken]
 
 	return state, ok
@@ -310,8 +317,8 @@ func (s *Server) GetPTZState(profileToken string) (*PTZState, bool) {
 
 // GetImagingState returns the current imaging state for a video source.
 func (s *Server) GetImagingState(videoSourceToken string) (*ImagingState, bool) {
-	imagingMutex.RLock()
-	defer imagingMutex.RUnlock()
+	s.imagingMu.RLock()
+	defer s.imagingMu.RUnlock()
 	state, ok := s.imagingState[videoSourceToken]
 
 	return state, ok

--- a/server/soap/handler.go
+++ b/server/soap/handler.go
@@ -4,22 +4,35 @@ package soap
 import (
 	"bytes"
 	"crypto/sha1" //nolint:gosec // SHA1 used for ONVIF digest authentication
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	originsoap "github.com/0x524a/onvif-go/internal/soap"
 )
+
+// maxClockSkew is the maximum allowed difference between a WS-Security
+// UsernameToken's Created timestamp and the server's clock.
+const maxClockSkew = 5 * time.Minute
 
 // Handler handles incoming SOAP requests.
 type Handler struct {
 	username string
 	password string
 	handlers map[string]MessageHandler
+
+	// nonceMu guards seenNonces, a replay cache for WS-Security nonces.
+	// It is scoped per Handler instance: each ONVIF service (device,
+	// media, PTZ, imaging) gets its own Handler in server.go, so replay
+	// protection is per-service rather than server-wide.
+	nonceMu    sync.Mutex
+	seenNonces map[string]time.Time
 }
 
 // MessageHandler is a function that handles a specific SOAP message.
@@ -28,15 +41,31 @@ type MessageHandler func(body interface{}) (interface{}, error)
 // NewHandler creates a new SOAP handler.
 func NewHandler(username, password string) *Handler {
 	return &Handler{
-		username: username,
-		password: password,
-		handlers: make(map[string]MessageHandler),
+		username:   username,
+		password:   password,
+		handlers:   make(map[string]MessageHandler),
+		seenNonces: make(map[string]time.Time),
 	}
 }
 
 // RegisterHandler registers a handler for a specific action/message type.
 func (h *Handler) RegisterHandler(action string, handler MessageHandler) {
 	h.handlers[action] = handler
+}
+
+// requestEnvelope decodes an incoming SOAP request. Unlike originsoap.Envelope
+// (which is used for marshaling outgoing requests/responses across the whole
+// package), Body.Content here is []byte with ",innerxml" rather than
+// interface{} — encoding/xml cannot populate a bare interface{} field, so
+// using originsoap.Envelope here would leave the request body silently nil.
+// The XMLName tag must match originsoap.Envelope's own tag so a non-SOAP
+// root element still gets rejected instead of unmarshaling successfully.
+type requestEnvelope struct {
+	XMLName xml.Name           `xml:"http://www.w3.org/2003/05/soap-envelope Envelope"`
+	Header  *originsoap.Header `xml:"Header,omitempty"`
+	Body    struct {
+		Content []byte `xml:",innerxml"`
+	} `xml:"Body"`
 }
 
 // ServeHTTP implements http.Handler interface.
@@ -66,16 +95,18 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Parse SOAP envelope
-	var envelope originsoap.Envelope
+	var envelope requestEnvelope
 	if err := xml.Unmarshal(body, &envelope); err != nil {
 		h.sendFault(w, "Sender", "Invalid SOAP envelope", err.Error())
 
 		return
 	}
 
-	// Authenticate if credentials are configured
-	if h.username != "" && h.password != "" {
-		if !h.authenticate(&envelope) {
+	// Authenticate if credentials are configured. Either field being set
+	// requires auth - a partially-configured Handler (e.g. username set,
+	// password empty by mistake) must not silently fall back to no-auth.
+	if h.username != "" || h.password != "" {
+		if !h.authenticate(envelope.Header) {
 			h.sendFault(w, "Sender", "Authentication failed", "Invalid username or password")
 
 			return
@@ -103,15 +134,24 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // authenticate verifies the WS-Security credentials.
-func (h *Handler) authenticate(envelope *originsoap.Envelope) bool {
-	if envelope.Header == nil || envelope.Header.Security == nil || envelope.Header.Security.UsernameToken == nil {
+func (h *Handler) authenticate(header *originsoap.Header) bool {
+	if header == nil || header.Security == nil || header.Security.UsernameToken == nil {
 		return false
 	}
 
-	token := envelope.Header.Security.UsernameToken
+	token := header.Security.UsernameToken
 
 	// Check username
 	if token.Username != h.username {
+		return false
+	}
+
+	// Reject stale or malformed timestamps before anything else.
+	created, err := time.Parse(time.RFC3339, token.Created)
+	if err != nil {
+		return false
+	}
+	if skew := time.Since(created); skew > maxClockSkew || skew < -maxClockSkew {
 		return false
 	}
 
@@ -128,8 +168,40 @@ func (h *Handler) authenticate(envelope *originsoap.Envelope) bool {
 	hash.Write([]byte(h.password))
 	expectedDigest := base64.StdEncoding.EncodeToString(hash.Sum(nil))
 
-	// Compare digests
-	return token.Password.Password == expectedDigest
+	// Compare digests in constant time to avoid a timing side-channel.
+	if subtle.ConstantTimeCompare([]byte(token.Password.Password), []byte(expectedDigest)) != 1 {
+		return false
+	}
+
+	// Reject a nonce+timestamp combination that's already been used, i.e.
+	// a replayed request.
+	return h.checkAndRecordNonce(token.Nonce.Nonce, token.Created)
+}
+
+// checkAndRecordNonce returns false if the given nonce+created combination
+// has already been seen (a replay), otherwise records it and returns true.
+// Entries older than maxClockSkew are purged lazily on each call, since
+// authenticate already rejects timestamps outside that window - anything
+// older can never pass authentication again anyway.
+func (h *Handler) checkAndRecordNonce(nonce, created string) bool {
+	key := nonce + "|" + created
+	now := time.Now()
+
+	h.nonceMu.Lock()
+	defer h.nonceMu.Unlock()
+
+	for k, seenAt := range h.seenNonces {
+		if now.Sub(seenAt) > maxClockSkew {
+			delete(h.seenNonces, k)
+		}
+	}
+
+	if _, exists := h.seenNonces[key]; exists {
+		return false
+	}
+	h.seenNonces[key] = now
+
+	return true
 }
 
 // extractAction extracts the action/message type from the SOAP body.

--- a/server/soap/handler_test.go
+++ b/server/soap/handler_test.go
@@ -11,16 +11,21 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 const testXMLHeader = `<?xml version="1.0"?>`
 
 const testResultSuccess = "Success"
 
-const (
-	testNonce   = "test_nonce_12345"
-	testCreated = "2024-01-01T00:00:00Z"
-)
+const testNonce = "test_nonce_12345"
+
+// freshCreated returns a Created timestamp within the server's clock-skew
+// window. A fixed historical timestamp would now be rejected outright by
+// the skew check before auth even reaches the password comparison.
+func freshCreated() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}
 
 // testActionResponse is the response body shared by the handler tests. It has to
 // be a struct rather than a map: encoding/xml cannot marshal maps, so a map would
@@ -251,12 +256,13 @@ func TestSendResponse(t *testing.T) {
 	}
 }
 
-// securitySOAPRequest builds a SOAP request carrying a WS-Security UsernameToken.
-// The digest is computed over digestPassword, so a caller can send either a
-// correct digest or a deliberately wrong one.
-func securitySOAPRequest(username, digestPassword, nonce, created string) string {
+// securitySOAPRequest builds a SOAP request carrying a WS-Security UsernameToken
+// for the "admin" user configured by every caller in this file, using the
+// shared testNonce. The digest is computed over digestPassword, so a caller
+// can send either a correct digest or a deliberately wrong one.
+func securitySOAPRequest(digestPassword, created string) string {
 	hash := sha1.New()
-	hash.Write([]byte(nonce))
+	hash.Write([]byte(testNonce))
 	hash.Write([]byte(created))
 	hash.Write([]byte(digestPassword))
 	digest := base64.StdEncoding.EncodeToString(hash.Sum(nil))
@@ -268,9 +274,9 @@ func securitySOAPRequest(username, digestPassword, nonce, created string) string
   <soap:Header>
     <wsse:Security>
       <wsse:UsernameToken>
-        <wsse:Username>` + username + `</wsse:Username>
+        <wsse:Username>admin</wsse:Username>
         <wsse:Password>` + digest + `</wsse:Password>
-        <wsse:Nonce>` + base64.StdEncoding.EncodeToString([]byte(nonce)) + `</wsse:Nonce>
+        <wsse:Nonce>` + base64.StdEncoding.EncodeToString([]byte(testNonce)) + `</wsse:Nonce>
         <wsu:Created>` + created + `</wsu:Created>
       </wsse:UsernameToken>
     </wsse:Security>
@@ -288,7 +294,7 @@ func TestAuthenticate(t *testing.T) {
 	})
 
 	req := httptest.NewRequestWithContext(context.Background(), "POST", "/",
-		strings.NewReader(securitySOAPRequest("admin", "password", testNonce, testCreated)))
+		strings.NewReader(securitySOAPRequest("password", freshCreated())))
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)
@@ -311,7 +317,7 @@ func TestAuthenticateFailsWithWrongPassword(t *testing.T) {
 	})
 
 	req := httptest.NewRequestWithContext(context.Background(), "POST", "/",
-		strings.NewReader(securitySOAPRequest("admin", "wrong_password", testNonce, testCreated)))
+		strings.NewReader(securitySOAPRequest("wrong_password", freshCreated())))
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)
@@ -319,6 +325,74 @@ func TestAuthenticateFailsWithWrongPassword(t *testing.T) {
 	// Should fail authentication
 	if !strings.Contains(w.Body.String(), "Fault") {
 		t.Errorf("Expected authentication failure")
+	}
+}
+
+func TestAuthenticateRejectsReplayedNonce(t *testing.T) {
+	handler := NewHandler("admin", "password")
+	handler.RegisterHandler("TestAction", func(body interface{}) (interface{}, error) {
+		return &testActionResponse{Result: testResultSuccess}, nil
+	})
+
+	soapBody := securitySOAPRequest("password", freshCreated())
+
+	req1 := httptest.NewRequestWithContext(context.Background(), "POST", "/", strings.NewReader(soapBody))
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+
+	if w1.Code != http.StatusOK {
+		t.Fatalf("First request with a fresh nonce should succeed, got %d: %s", w1.Code, w1.Body.String())
+	}
+
+	req2 := httptest.NewRequestWithContext(context.Background(), "POST", "/", strings.NewReader(soapBody))
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+
+	if !strings.Contains(w2.Body.String(), "Fault") {
+		t.Errorf("Replaying the same nonce+timestamp should fail authentication, got: %s", w2.Body.String())
+	}
+}
+
+func TestAuthenticateRejectsStaleTimestamp(t *testing.T) {
+	handler := NewHandler("admin", "password")
+	handler.RegisterHandler("TestAction", func(body interface{}) (interface{}, error) {
+		return &testActionResponse{Result: testResultSuccess}, nil
+	})
+
+	staleCreated := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "/",
+		strings.NewReader(securitySOAPRequest("password", staleCreated)))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if !strings.Contains(w.Body.String(), "Fault") {
+		t.Errorf("A stale (1h old) Created timestamp should fail authentication, got: %s", w.Body.String())
+	}
+}
+
+func TestAuthenticateRequiredWithPartialCredentials(t *testing.T) {
+	// Configuring only a username (empty password) must still enforce
+	// auth rather than silently falling back to no-auth mode.
+	handler := NewHandler("admin", "")
+	handler.RegisterHandler("TestAction", func(body interface{}) (interface{}, error) {
+		return &testActionResponse{Result: "should not reach here"}, nil
+	})
+
+	soapBody := testXMLHeader + `
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+  <soap:Body>
+    <TestAction/>
+  </soap:Body>
+</soap:Envelope>`
+
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "/", strings.NewReader(soapBody))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if !strings.Contains(w.Body.String(), "Fault") {
+		t.Errorf("A request with no security header should fail authentication when username is configured, got: %s", w.Body.String())
 	}
 }
 
@@ -434,5 +508,86 @@ func TestContentType(t *testing.T) {
 	// Handler should work regardless of content type
 	if w.Code == http.StatusInternalServerError {
 		t.Logf("Note: Handler may validate content type")
+	}
+}
+
+// TestServeHTTPDecodesParameterizedRequestBody is a regression test for a bug
+// where every parameterized operation always received a nil body: Envelope's
+// Body.Content field was interface{}, which encoding/xml cannot populate, so
+// every such request always failed with an EOF-turned-Fault regardless of
+// what the client actually sent. This drives a realistic request body
+// through the real wire path (ServeHTTP) rather than calling a handler
+// function directly, and asserts the handler actually decoded a field from
+// it - not just that the response wasn't a 500.
+func TestServeHTTPDecodesParameterizedRequestBody(t *testing.T) {
+	handler := NewHandler("", "")
+
+	type getStreamURIRequest struct {
+		XMLName      xml.Name `xml:"GetStreamURI"`
+		ProfileToken string   `xml:"ProfileToken"`
+	}
+
+	var gotToken string
+	handler.RegisterHandler("GetStreamURI", func(body interface{}) (interface{}, error) {
+		bodyBytes, ok := body.([]byte)
+		if !ok {
+			t.Fatalf("expected handler body to be []byte, got %T", body)
+		}
+
+		var req getStreamURIRequest
+		if err := xml.Unmarshal(bodyBytes, &req); err != nil {
+			t.Fatalf("failed to unmarshal request body: %v", err)
+		}
+		gotToken = req.ProfileToken
+
+		return &testActionResponse{Result: testResultSuccess}, nil
+	})
+
+	soapBody := testXMLHeader + `
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+  <soap:Body>
+    <GetStreamURI xmlns="http://www.onvif.org/ver10/media/wsdl">
+      <ProfileToken>Profile1</ProfileToken>
+    </GetStreamURI>
+  </soap:Body>
+</soap:Envelope>`
+
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "/", strings.NewReader(soapBody))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if gotToken != "Profile1" {
+		t.Errorf("Expected handler to decode ProfileToken %q, got %q", "Profile1", gotToken)
+	}
+}
+
+// TestServeHTTPRejectsNonSOAPRoot ensures the decode-only requestEnvelope
+// type still validates the root element namespace/name like the original
+// originsoap.Envelope did, rather than silently accepting anything with a
+// Body element.
+func TestServeHTTPRejectsNonSOAPRoot(t *testing.T) {
+	handler := NewHandler("", "")
+	handler.RegisterHandler("TestAction", func(body interface{}) (interface{}, error) {
+		return &testActionResponse{Result: testResultSuccess}, nil
+	})
+
+	notASOAPEnvelope := testXMLHeader + `
+<NotSoap>
+  <Body>
+    <TestAction/>
+  </Body>
+</NotSoap>`
+
+	req := httptest.NewRequestWithContext(context.Background(), "POST", "/", strings.NewReader(notASOAPEnvelope))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if !strings.Contains(w.Body.String(), "Fault") {
+		t.Errorf("Expected a fault for a non-SOAP root element, got: %s", w.Body.String())
 	}
 }

--- a/server/types.go
+++ b/server/types.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/0x524a/onvif-go"
@@ -199,6 +200,17 @@ type Server struct {
 	ptzState     map[string]*PTZState     // Profile token -> PTZ state
 	imagingState map[string]*ImagingState // Video source token -> imaging state
 	systemTime   time.Time
+
+	// streamsMu guards the mutable fields of the *StreamConfig values in
+	// streams (the map itself is populated once in New and never re-keyed).
+	streamsMu sync.RWMutex
+
+	// ptzMu and imagingMu guard the mutable fields of the *PTZState /
+	// *ImagingState values in ptzState / imagingState respectively. These
+	// are per-Server fields rather than package-level so that multiple
+	// Server instances in one process don't serialize through one lock.
+	ptzMu     sync.RWMutex
+	imagingMu sync.RWMutex
 }
 
 // PTZState represents the current PTZ state.
@@ -209,6 +221,11 @@ type PTZState struct {
 	TiltMoving bool
 	ZoomMoving bool
 	LastUpdate time.Time
+
+	// settleTimer, when non-nil, is the pending timer that will clear the
+	// Moving/PanMoving/TiltMoving/ZoomMoving flags once a simulated move
+	// settles. Guarded by the owning Server's ptzMu.
+	settleTimer *time.Timer
 }
 
 // ImagingState represents the current imaging settings state.


### PR DESCRIPTION
## Summary

Fixes 7 confirmed correctness bugs in `server/`, `server/soap/`, and `discovery/`, found and independently verified (including empirical repros, not just read-throughs) in a broader review of the `server/` virtual camera simulator.

- **Critical — every parameterized server operation always faulted.** `originsoap.Body.Content` was `interface{}`, which `encoding/xml` cannot populate on decode, so `ContinuousMove`, `GetStreamURI`, `SetImagingSettings`, and every other operation with a request body (12 call sites) always received a nil body and returned a SOAP Fault, regardless of what the client sent. Fixed with a decode-only `requestEnvelope` type scoped to `ServeHTTP`'s request path — the shared marshal-side `originsoap.Envelope`/`Body` types (used by ~200 client APIs and ~100 already-working server responses) are untouched.
- **Data race** on `StreamConfig.StreamURI` — `UpdateStreamURI` wrote it unguarded while handlers read it unguarded. Added `streamsMu`.
- **Package-global mutexes** — `ptzMutex`/`imagingMutex` were package-level `var`s, so every `Server` instance in a process shared one lock each. Moved onto the `Server` struct.
- **Leaking/uncancellable PTZ goroutines** — `AbsoluteMove`/`RelativeMove`/`GotoPreset` each spawned a bare `go func(){ time.Sleep(...) }()` to clear the `Moving` flags; two rapid moves for the same profile left two goroutines racing to clear the same state. Replaced with a per-profile `time.AfterFunc`, cancelled by a new move or by `Stop`.
- **Non-RFC-4122 UUID** in WS-Discovery — `generateUUID` built a wall-clock-derived string by hand; now uses `google/uuid` (promoted from an indirect to a direct dependency via `go mod tidy`).
- **`GetOptions` ignored its argument** — returned static imaging capabilities even for a `VideoSourceToken` that doesn't exist. Now validates it like its sibling `GetImagingSettings`.
- **Weak WS-Security auth** — digest comparison is now constant-time, `Created` is checked against a 5-minute clock-skew window, a per-`Handler` nonce replay cache rejects repeated requests, and auth is no longer silently skipped when only one of username/password is configured (previously required both).

Each fix was scoped by tracing exactly what depends on the code being changed, specifically so nothing already-working breaks — see the commit message for the "naive fix would break ~300 things" trap on the SOAP decode change in particular.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test -race ./...` — all packages pass, including a new race-covering test for the stream URI fix
- [x] `golangci-lint run --timeout=5m --max-issues-per-linter=0 --max-same-issues=0 ./...` — 0 issues
- [x] New real end-to-end test: a real `internal/soap.Client` against a real `httptest.NewServer` wrapping the actual `server/` mux, driving `ContinuousMove` over genuine HTTP and asserting server-side PTZ state changed — this is the "no test exercises the real wire path" gap called out by finding #2, closed directly
- [x] Manual smoke test: ran the real `onvif-server` binary and hit it with the real public `onvif.Client` — `ContinuousMove` now succeeds (200, state actually updates) where it previously always faulted
- [x] New regression tests for each of the other 6 fixes (replayed-nonce rejection, stale-timestamp rejection, partial-credentials still enforcing auth, PTZ settle-timer cancellation on a repeated move and on `Stop`, UUID format/uniqueness, `GetOptions` unknown-token rejection)

## Related

While smoke-testing, found that the real client and the simulator disagree on action-name casing for `GetStreamURI`/`GetSnapshotURI` (`GetStreamUri` vs `GetStreamURI`), making those two ops non-interoperable independent of anything in this PR. Filed separately as #79 rather than folding into this branch.