### PR TITLE
fix(server): correct GetStreamUri/GetSnapshotUri action-name casing

### DIFF
--- a/server/media.go
+++ b/server/media.go
@@ -137,7 +137,10 @@ type IPAddress struct {
 
 // GetStreamURIResponse represents GetStreamURI response.
 type GetStreamURIResponse struct {
-	XMLName  xml.Name `xml:"http://www.onvif.org/ver10/media/wsdl GetStreamURIResponse"`
+	// Element name is "GetStreamUriResponse" (lowercase "Uri") per the
+	// ONVIF Media WSDL and what the real client expects (#79) - only the
+	// wire name needs to match, not the Go type name.
+	XMLName  xml.Name `xml:"http://www.onvif.org/ver10/media/wsdl GetStreamUriResponse"`
 	MediaURI MediaURI `xml:"MediaUri"`
 }
 
@@ -151,7 +154,9 @@ type MediaURI struct {
 
 // GetSnapshotURIResponse represents GetSnapshotURI response.
 type GetSnapshotURIResponse struct {
-	XMLName  xml.Name `xml:"http://www.onvif.org/ver10/media/wsdl GetSnapshotURIResponse"`
+	// See GetStreamURIResponse.XMLName - same lowercase "Uri" wire name
+	// requirement (#79).
+	XMLName  xml.Name `xml:"http://www.onvif.org/ver10/media/wsdl GetSnapshotUriResponse"`
 	MediaURI MediaURI `xml:"MediaUri"`
 }
 

--- a/server/media_action_names_test.go
+++ b/server/media_action_names_test.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	onvif "github.com/0x524a/onvif-go"
+)
+
+// TestMediaServiceActionNamesMatchRealClient is a regression test for #79:
+// the simulator registered GetStreamURI/GetSnapshotURI under the wrong
+// action-name casing ("GetStreamURI"/"GetSnapshotURI") while the real
+// client - and the ONVIF Media WSDL itself - spell them
+// "GetStreamUri"/"GetSnapshotUri". soap.Handler.extractAction dispatches on
+// the literal element name case-sensitively, so every call from a real
+// onvif.Client to either operation always faulted with "Action not
+// supported", regardless of what the client sent.
+//
+// This drives the real, public onvif.Client (the same one used against
+// real cameras) against a real httptest server wrapping the actual
+// registerMediaService mux - the only kind of test that would have caught
+// this, since every existing direct-handler test in this package calls
+// Handle* functions directly and bypasses SOAP action dispatch entirely.
+func TestMediaServiceActionNamesMatchRealClient(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	srv.registerMediaService(mux)
+
+	testServer := httptest.NewServer(mux)
+	defer testServer.Close()
+
+	client, err := onvif.NewClient(
+		testServer.URL+config.BasePath+"/media_service",
+		onvif.WithCredentials(config.Username, config.Password),
+		onvif.WithHTTPClient(testServer.Client()),
+	)
+	if err != nil {
+		t.Fatalf("onvif.NewClient() failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	profileToken := config.Profiles[0].Token
+
+	if _, err := client.GetStreamURI(ctx, profileToken); err != nil {
+		t.Errorf("GetStreamURI over the real wire path failed: %v", err)
+	}
+	if _, err := client.GetSnapshotURI(ctx, profileToken); err != nil {
+		t.Errorf("GetSnapshotURI over the real wire path failed: %v", err)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -194,10 +194,14 @@ func (s *Server) registerDeviceService(mux *http.ServeMux) {
 func (s *Server) registerMediaService(mux *http.ServeMux) {
 	handler := soap.NewHandler(s.config.Username, s.config.Password)
 
-	// Register media service handlers
+	// Register media service handlers. GetStreamUri/GetSnapshotUri are
+	// registered under the ONVIF Media WSDL's actual spelling (lowercase
+	// "Uri") - the real onvif.Client sends exactly that, and action
+	// dispatch in soap.Handler.extractAction is case-sensitive, so a
+	// "GetStreamURI" registration here silently never matches (#79).
 	handler.RegisterHandler("GetProfiles", s.HandleGetProfiles)
-	handler.RegisterHandler("GetStreamURI", s.HandleGetStreamURI)
-	handler.RegisterHandler("GetSnapshotURI", s.HandleGetSnapshotURI)
+	handler.RegisterHandler("GetStreamUri", s.HandleGetStreamURI)
+	handler.RegisterHandler("GetSnapshotUri", s.HandleGetSnapshotURI)
 	handler.RegisterHandler("GetVideoSources", s.HandleGetVideoSources)
 
 	mux.Handle(s.config.BasePath+"/media_service", handler)


### PR DESCRIPTION
Fixes #79.

## Summary

The virtual server registered `GetStreamURI`/`GetSnapshotURI` (capital `URI`), but the real `onvif.Client` - and the ONVIF Media WSDL itself - spell them `GetStreamUri`/`GetSnapshotUri` (lowercase `i`). `soap.Handler.extractAction` dispatches on the literal action element name case-sensitively, so a real client calling either operation against `server/` always got `Action not supported`.

The response types had the identical mismatch in reverse: `XMLName` said `GetStreamURIResponse`/`GetSnapshotURIResponse`, but the real client's response structs expect the lowercase-`i` spelling. Fixed both directions. Go type/identifier names (`GetStreamURIResponse`, `HandleGetStreamURI`, etc.) are untouched - only the wire-level XML tag *values* needed to change.

## Why this targets `fix/server-correctness-bugs-part1` (#80) instead of `master`

The regression test drives a real `onvif.Client` through the real wire path, which needs a request body that actually decodes - that depends on #80's fix for the `interface{}` decode bug (finding #1 from the original review). On `master` alone, the action-name fix correctly routes the request to the handler, but the handler then hits that separate, already-fixed-elsewhere bug and the test can't cleanly prove success. **Merge #80 first, then this.**

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test -race ./...` — all packages pass
- [x] `golangci-lint run --timeout=5m --max-issues-per-linter=0 --max-same-issues=0 ./...` — 0 issues
- [x] New test `TestMediaServiceActionNamesMatchRealClient`: the real public `onvif.Client` against an `httptest.NewServer` wrapping the actual `registerMediaService` mux, calling `GetStreamURI` and `GetSnapshotURI` - the only kind of test that would have caught this, since every existing direct-handler test bypasses SOAP action dispatch entirely