### PR TITLE
fix(client): make Client's mutex actually guard endpoints and credentials

### DIFF
--- a/client.go
+++ b/client.go
@@ -204,6 +204,7 @@ func (c *Client) Initialize(ctx context.Context) error {
 
 	// Extract service endpoints and fix any localhost addresses
 	// Some cameras incorrectly report localhost instead of their actual IP
+	c.mu.Lock()
 	if capabilities.Media != nil && capabilities.Media.XAddr != "" {
 		c.mediaEndpoint = c.fixLocalhostURL(capabilities.Media.XAddr)
 	}
@@ -216,6 +217,7 @@ func (c *Client) Initialize(ctx context.Context) error {
 	if capabilities.Events != nil && capabilities.Events.XAddr != "" {
 		c.eventEndpoint = c.fixLocalhostURL(capabilities.Events.XAddr)
 	}
+	c.mu.Unlock()
 
 	return nil
 }
@@ -274,8 +276,9 @@ func (c *Client) downloadWithBasicAuth(ctx context.Context, downloadURL string) 
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	if c.username != "" {
-		req.SetBasicAuth(c.username, c.password)
+	username, password := c.GetCredentials()
+	if username != "" {
+		req.SetBasicAuth(username, password)
 	}
 
 	req.Header.Set("User-Agent", "onvif-go-client")
@@ -325,7 +328,8 @@ func (c *Client) downloadWithBasicAuth(ctx context.Context, downloadURL string) 
 
 // downloadWithDigestAuth performs an HTTP download with Digest authentication.
 func (c *Client) downloadWithDigestAuth(ctx context.Context, downloadURL string) ([]byte, error) {
-	if c.username == "" {
+	username, password := c.GetCredentials()
+	if username == "" {
 		return nil, fmt.Errorf("%w", ErrDigestAuthRequiresCredentials)
 	}
 
@@ -344,8 +348,8 @@ func (c *Client) downloadWithDigestAuth(ctx context.Context, downloadURL string)
 	digestClient := &http.Client{
 		Transport: &digestAuthTransport{
 			transport: tr,
-			username:  c.username,
-			password:  c.password,
+			username:  username,
+			password:  password,
 		},
 		Timeout: DefaultTimeout,
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -1199,6 +1200,53 @@ func TestClientConcurrency(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		<-done
 	}
+}
+
+// TestClientEndpointAndCredentialRace exercises Initialize concurrently with
+// reads of the discovered service endpoints and with SetCredentials/
+// GetCredentials, catching the data races that existed before c.mu guarded
+// mediaEndpoint/ptzEndpoint/imagingEndpoint and the download helpers. Run
+// with -race.
+func TestClientEndpointAndCredentialRace(t *testing.T) {
+	mock := NewMockONVIFServer()
+	defer mock.Close()
+
+	client, err := NewClient(mock.URL(), WithCredentials(testUsername, "password"))
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(6)
+		go func() {
+			defer wg.Done()
+			_ = client.Initialize(ctx)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = client.getMediaEndpoint()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = client.getPTZEndpoint()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = client.getImagingEndpoint()
+		}()
+		go func(n int) {
+			defer wg.Done()
+			client.SetCredentials(fmt.Sprintf("user%d", n), "pass")
+		}(i)
+		go func() {
+			defer wg.Done()
+			_, _ = client.GetCredentials()
+		}()
+	}
+	wg.Wait()
 }
 
 // TestNormalizeEndpointErrorCases tests error cases for normalizeEndpoint.

--- a/imaging.go
+++ b/imaging.go
@@ -11,11 +11,19 @@ import (
 // Imaging service namespace.
 const imagingNamespace = "http://www.onvif.org/ver20/imaging/wsdl"
 
+// getImagingEndpoint returns the imaging endpoint.
+func (c *Client) getImagingEndpoint() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.imagingEndpoint
+}
+
 // GetImagingSettings retrieves imaging settings for a video source.
 //
 //nolint:funlen // GetImagingSettings has many statements due to parsing complex imaging settings
 func (c *Client) GetImagingSettings(ctx context.Context, videoSourceToken string) (*ImagingSettings, error) {
-	endpoint := c.imagingEndpoint
+	endpoint := c.getImagingEndpoint()
 	if endpoint == "" {
 		endpoint = c.endpoint
 	}
@@ -147,7 +155,7 @@ func (c *Client) GetImagingSettings(ctx context.Context, videoSourceToken string
 func (c *Client) SetImagingSettings(
 	ctx context.Context, videoSourceToken string, settings *ImagingSettings, forcePersistence bool,
 ) error {
-	endpoint := c.imagingEndpoint
+	endpoint := c.getImagingEndpoint()
 	if endpoint == "" {
 		endpoint = c.endpoint
 	}
@@ -297,7 +305,7 @@ func (c *Client) SetImagingSettings(
 
 // Move performs a focus move operation.
 func (c *Client) Move(ctx context.Context, videoSourceToken string, focus *FocusMove) error {
-	endpoint := c.imagingEndpoint
+	endpoint := c.getImagingEndpoint()
 	if endpoint == "" {
 		endpoint = c.endpoint
 	}
@@ -360,7 +368,7 @@ type FocusMove struct {
 
 // GetOptions retrieves imaging options for a video source.
 func (c *Client) GetOptions(ctx context.Context, videoSourceToken string) (*ImagingOptions, error) {
-	endpoint := c.imagingEndpoint
+	endpoint := c.getImagingEndpoint()
 	if endpoint == "" {
 		return nil, ErrServiceNotSupported
 	}
@@ -457,7 +465,7 @@ func (c *Client) GetOptions(ctx context.Context, videoSourceToken string) (*Imag
 
 // GetMoveOptions retrieves imaging move options for focus.
 func (c *Client) GetMoveOptions(ctx context.Context, videoSourceToken string) (*MoveOptions, error) {
-	endpoint := c.imagingEndpoint
+	endpoint := c.getImagingEndpoint()
 	if endpoint == "" {
 		return nil, ErrServiceNotSupported
 	}
@@ -556,7 +564,7 @@ func (c *Client) GetMoveOptions(ctx context.Context, videoSourceToken string) (*
 
 // StopFocus stops focus movement.
 func (c *Client) StopFocus(ctx context.Context, videoSourceToken string) error {
-	endpoint := c.imagingEndpoint
+	endpoint := c.getImagingEndpoint()
 	if endpoint == "" {
 		return ErrServiceNotSupported
 	}
@@ -584,7 +592,7 @@ func (c *Client) StopFocus(ctx context.Context, videoSourceToken string) error {
 
 // GetImagingStatus retrieves imaging status.
 func (c *Client) GetImagingStatus(ctx context.Context, videoSourceToken string) (*ImagingStatus, error) {
-	endpoint := c.imagingEndpoint
+	endpoint := c.getImagingEndpoint()
 	if endpoint == "" {
 		return nil, ErrServiceNotSupported
 	}

--- a/imaging_test.go
+++ b/imaging_test.go
@@ -1,0 +1,124 @@
+package onvif
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+)
+
+// newImagingTestClient returns a Client whose imagingEndpoint points at server.
+func newImagingTestClient(t *testing.T, server *httptest.Server) *Client {
+	t.Helper()
+
+	client, err := NewClient(server.URL, WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+	client.imagingEndpoint = server.URL
+
+	return client
+}
+
+func TestGetImagingSettings(t *testing.T) {
+	body := `<GetImagingSettingsResponse>
+        <ImagingSettings>
+            <Brightness>50</Brightness>
+            <Contrast>60</Contrast>
+        </ImagingSettings>
+    </GetImagingSettingsResponse>`
+	client := newImagingTestClient(t, newSOAPTestServer(t, body))
+
+	settings, err := client.GetImagingSettings(context.Background(), "videosource1")
+	if err != nil {
+		t.Fatalf("GetImagingSettings() error = %v", err)
+	}
+	if settings.Brightness == nil || *settings.Brightness != 50 {
+		t.Errorf("GetImagingSettings() Brightness = %v, want 50", settings.Brightness)
+	}
+}
+
+func TestSetImagingSettings(t *testing.T) {
+	client := newImagingTestClient(t, newSOAPTestServer(t, soapAckOnlyResponse))
+
+	brightness := 75.0
+	err := client.SetImagingSettings(context.Background(), "videosource1", &ImagingSettings{Brightness: &brightness}, false)
+	if err != nil {
+		t.Errorf("SetImagingSettings() error = %v", err)
+	}
+}
+
+func TestImagingMove(t *testing.T) {
+	client := newImagingTestClient(t, newSOAPTestServer(t, soapAckOnlyResponse))
+
+	// FocusMove is currently a placeholder struct in the client (imaging.go)
+	// with no move-type fields yet, so there is nothing to populate here.
+	err := client.Move(context.Background(), "videosource1", &FocusMove{})
+	if err != nil {
+		t.Errorf("Move() error = %v", err)
+	}
+}
+
+func TestImagingGetOptions(t *testing.T) {
+	body := `<GetOptionsResponse>
+        <ImagingOptions>
+            <Brightness><Min>0</Min><Max>100</Max></Brightness>
+        </ImagingOptions>
+    </GetOptionsResponse>`
+	client := newImagingTestClient(t, newSOAPTestServer(t, body))
+
+	options, err := client.GetOptions(context.Background(), "videosource1")
+	if err != nil {
+		t.Fatalf("GetOptions() error = %v", err)
+	}
+	if options.Brightness == nil || options.Brightness.Max != 100 {
+		t.Errorf("GetOptions() Brightness = %+v, want Max=100", options.Brightness)
+	}
+}
+
+func TestGetMoveOptions(t *testing.T) {
+	body := `<GetMoveOptionsResponse>
+        <MoveOptions>
+            <Absolute>
+                <Position><Min>0</Min><Max>1</Max></Position>
+                <Speed><Min>0</Min><Max>1</Max></Speed>
+            </Absolute>
+        </MoveOptions>
+    </GetMoveOptionsResponse>`
+	client := newImagingTestClient(t, newSOAPTestServer(t, body))
+
+	options, err := client.GetMoveOptions(context.Background(), "videosource1")
+	if err != nil {
+		t.Fatalf("GetMoveOptions() error = %v", err)
+	}
+	if options.Absolute == nil || options.Absolute.Position.Max != 1 {
+		t.Errorf("GetMoveOptions() Absolute = %+v, want Position.Max=1", options.Absolute)
+	}
+}
+
+func TestStopFocus(t *testing.T) {
+	client := newImagingTestClient(t, newSOAPTestServer(t, soapAckOnlyResponse))
+
+	if err := client.StopFocus(context.Background(), "videosource1"); err != nil {
+		t.Errorf("StopFocus() error = %v", err)
+	}
+}
+
+func TestGetImagingStatus(t *testing.T) {
+	body := `<GetStatusResponse>
+        <Status>
+            <FocusStatus>
+                <Position>0.42</Position>
+                <MoveStatus>IDLE</MoveStatus>
+            </FocusStatus>
+        </Status>
+    </GetStatusResponse>`
+	client := newImagingTestClient(t, newSOAPTestServer(t, body))
+
+	status, err := client.GetImagingStatus(context.Background(), "videosource1")
+	if err != nil {
+		t.Fatalf("GetImagingStatus() error = %v", err)
+	}
+	if status.FocusStatus == nil || status.FocusStatus.Position != 0.42 {
+		t.Errorf("GetImagingStatus() FocusStatus = %+v, want Position=0.42", status.FocusStatus)
+	}
+}

--- a/media.go
+++ b/media.go
@@ -15,6 +15,9 @@ const mediaNamespace = "http://www.onvif.org/ver10/media/wsdl"
 
 // getMediaEndpoint returns the media endpoint, falling back to the default endpoint if not set.
 func (c *Client) getMediaEndpoint() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if c.mediaEndpoint != "" {
 		return c.mediaEndpoint
 	}

--- a/ptz.go
+++ b/ptz.go
@@ -13,6 +13,9 @@ const ptzNamespace = "http://www.onvif.org/ver20/ptz/wsdl"
 
 // getPTZEndpoint returns the PTZ endpoint.
 func (c *Client) getPTZEndpoint() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.ptzEndpoint
 }
 

--- a/ptz.go
+++ b/ptz.go
@@ -11,6 +11,11 @@ import (
 // PTZ service namespace.
 const ptzNamespace = "http://www.onvif.org/ver20/ptz/wsdl"
 
+// getPTZEndpoint returns the PTZ endpoint.
+func (c *Client) getPTZEndpoint() string {
+	return c.ptzEndpoint
+}
+
 // ptzPanTiltXML is a shared type for PTZ pan/tilt XML serialization.
 type ptzPanTiltXML struct {
 	X     float64 `xml:"x,attr"`
@@ -70,7 +75,7 @@ func convertToPTZSpeedXML(s *PTZSpeed) *ptzSpeedXML {
 
 // ContinuousMove starts continuous PTZ movement.
 func (c *Client) ContinuousMove(ctx context.Context, profileToken string, velocity *PTZSpeed, timeout *string) error {
-	endpoint := c.ptzEndpoint
+	endpoint := c.getPTZEndpoint()
 	if endpoint == "" {
 		return ErrServiceNotSupported
 	}
@@ -102,7 +107,7 @@ func (c *Client) ContinuousMove(ctx context.Context, profileToken string, veloci
 
 // AbsoluteMove moves PTZ to an absolute position.
 func (c *Client) AbsoluteMove(ctx context.Context, profileToken string, position *PTZVector, speed *PTZSpeed) error {
-	endpoint := c.ptzEndpoint
+	endpoint := c.getPTZEndpoint()
 	if endpoint == "" {
 		return ErrServiceNotSupported
 	}
@@ -134,7 +139,7 @@ func (c *Client) AbsoluteMove(ctx context.Context, profileToken string, position
 
 // RelativeMove moves PTZ relative to current position.
 func (c *Client) RelativeMove(ctx context.Context, profileToken string, translation *PTZVector, speed *PTZSpeed) error {
-	endpoint := c.ptzEndpoint
+	endpoint := c.getPTZEndpoint()
 	if endpoint == "" {
 		return ErrServiceNotSupported
 	}
@@ -166,7 +171,7 @@ func (c *Client) RelativeMove(ctx context.Context, profileToken string, translat
 
 // Stop stops PTZ movement.
 func (c *Client) Stop(ctx context.Context, profileToken string, panTilt, zoom bool) error {
-	endpoint := c.ptzEndpoint
+	endpoint := c.getPTZEndpoint()
 	if endpoint == "" {
 		return ErrServiceNotSupported
 	}
@@ -203,7 +208,7 @@ func (c *Client) Stop(ctx context.Context, profileToken string, panTilt, zoom bo
 
 // GetStatus retrieves PTZ status.
 func (c *Client) GetStatus(ctx context.Context, profileToken string) (*PTZStatus, error) {
-	endpoint := c.ptzEndpoint
+	endpoint := c.getPTZEndpoint()
 	if endpoint == "" {
 		return nil, ErrServiceNotSupported
 	}
@@ -284,7 +289,7 @@ func (c *Client) GetStatus(ctx context.Context, profileToken string) (*PTZStatus
 
 // GetPresets retrieves PTZ presets.
 func (c *Client) GetPresets(ctx context.Context, profileToken string) ([]*PTZPreset, error) {
-	endpoint := c.ptzEndpoint
+	endpoint := c.getPTZEndpoint()
 	if endpoint == "" {
 		return nil, ErrServiceNotSupported
 	}
@@ -360,7 +365,7 @@ func (c *Client) GetPresets(ctx context.Context, profileToken string) ([]*PTZPre
 
 // GotoPreset moves PTZ to a preset position.
 func (c *Client) GotoPreset(ctx context.Context, profileToken, presetToken string, speed *PTZSpeed) error {
-	endpoint := c.ptzEndpoint
+	endpoint := c.getPTZEndpoint()
 	if endpoint == "" {
 		return ErrServiceNotSupported
 	}
@@ -392,7 +397,7 @@ func (c *Client) GotoPreset(ctx context.Context, profileToken, presetToken strin
 
 // SetPreset sets a preset position.
 func (c *Client) SetPreset(ctx context.Context, profileToken, presetName, presetToken string) (string, error) {
-	endpoint := c.ptzEndpoint
+	endpoint := c.getPTZEndpoint()
 	if endpoint == "" {
 		return "", ErrServiceNotSupported
 	}
@@ -436,7 +441,7 @@ func (c *Client) SetPreset(ctx context.Context, profileToken, presetName, preset
 
 // RemovePreset removes a preset.
 func (c *Client) RemovePreset(ctx context.Context, profileToken, presetToken string) error {
-	endpoint := c.ptzEndpoint
+	endpoint := c.getPTZEndpoint()
 	if endpoint == "" {
 		return ErrServiceNotSupported
 	}
@@ -466,7 +471,7 @@ func (c *Client) RemovePreset(ctx context.Context, profileToken, presetToken str
 
 // GotoHomePosition moves PTZ to home position.
 func (c *Client) GotoHomePosition(ctx context.Context, profileToken string, speed *PTZSpeed) error {
-	endpoint := c.ptzEndpoint
+	endpoint := c.getPTZEndpoint()
 	if endpoint == "" {
 		return ErrServiceNotSupported
 	}
@@ -496,7 +501,7 @@ func (c *Client) GotoHomePosition(ctx context.Context, profileToken string, spee
 
 // SetHomePosition sets the current position as home position.
 func (c *Client) SetHomePosition(ctx context.Context, profileToken string) error {
-	endpoint := c.ptzEndpoint
+	endpoint := c.getPTZEndpoint()
 	if endpoint == "" {
 		return ErrServiceNotSupported
 	}
@@ -524,7 +529,7 @@ func (c *Client) SetHomePosition(ctx context.Context, profileToken string) error
 
 // GetConfiguration retrieves PTZ configuration.
 func (c *Client) GetConfiguration(ctx context.Context, configurationToken string) (*PTZConfiguration, error) {
-	endpoint := c.ptzEndpoint
+	endpoint := c.getPTZEndpoint()
 	if endpoint == "" {
 		return nil, ErrServiceNotSupported
 	}
@@ -569,7 +574,7 @@ func (c *Client) GetConfiguration(ctx context.Context, configurationToken string
 
 // GetConfigurations retrieves all PTZ configurations.
 func (c *Client) GetConfigurations(ctx context.Context) ([]*PTZConfiguration, error) {
-	endpoint := c.ptzEndpoint
+	endpoint := c.getPTZEndpoint()
 	if endpoint == "" {
 		return nil, ErrServiceNotSupported
 	}

--- a/ptz_test.go
+++ b/ptz_test.go
@@ -1,6 +1,202 @@
 package onvif
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newSOAPTestServer returns an httptest.Server that responds to every
+// request with a fixed SOAP envelope wrapping body. Each test below only
+// ever calls one client method against it, so no action-based dispatch
+// (unlike MockONVIFServer's) is needed.
+func newSOAPTestServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/soap+xml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+    <soap:Body>` + body + `</soap:Body>
+</soap:Envelope>`))
+	}))
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+// newPTZTestClient returns a Client whose ptzEndpoint points at server.
+func newPTZTestClient(t *testing.T, server *httptest.Server) *Client {
+	t.Helper()
+
+	client, err := NewClient(server.URL, WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+	client.ptzEndpoint = server.URL
+
+	return client
+}
+
+const soapAckOnlyResponse = ""
+
+func TestContinuousMove(t *testing.T) {
+	client := newPTZTestClient(t, newSOAPTestServer(t, soapAckOnlyResponse))
+	if err := client.ContinuousMove(context.Background(), "profile1", &PTZSpeed{PanTilt: &Vector2D{X: 0.5}}, nil); err != nil {
+		t.Errorf("ContinuousMove() error = %v", err)
+	}
+}
+
+func TestAbsoluteMove(t *testing.T) {
+	client := newPTZTestClient(t, newSOAPTestServer(t, soapAckOnlyResponse))
+	if err := client.AbsoluteMove(context.Background(), "profile1", &PTZVector{PanTilt: &Vector2D{X: 1, Y: 2}}, nil); err != nil {
+		t.Errorf("AbsoluteMove() error = %v", err)
+	}
+}
+
+func TestRelativeMove(t *testing.T) {
+	client := newPTZTestClient(t, newSOAPTestServer(t, soapAckOnlyResponse))
+	if err := client.RelativeMove(context.Background(), "profile1", &PTZVector{PanTilt: &Vector2D{X: 1, Y: 2}}, nil); err != nil {
+		t.Errorf("RelativeMove() error = %v", err)
+	}
+}
+
+func TestPTZStop(t *testing.T) {
+	client := newPTZTestClient(t, newSOAPTestServer(t, soapAckOnlyResponse))
+	if err := client.Stop(context.Background(), "profile1", true, true); err != nil {
+		t.Errorf("Stop() error = %v", err)
+	}
+}
+
+func TestPTZGetStatus(t *testing.T) {
+	body := `<GetStatusResponse>
+        <PTZStatus>
+            <Position>
+                <PanTilt x="0.1" y="0.2" space="PanTiltSpace"/>
+                <Zoom x="0.3" space="ZoomSpace"/>
+            </Position>
+            <MoveStatus>
+                <PanTilt>IDLE</PanTilt>
+                <Zoom>IDLE</Zoom>
+            </MoveStatus>
+            <UtcTime>2026-01-01T00:00:00Z</UtcTime>
+        </PTZStatus>
+    </GetStatusResponse>`
+	client := newPTZTestClient(t, newSOAPTestServer(t, body))
+
+	status, err := client.GetStatus(context.Background(), "profile1")
+	if err != nil {
+		t.Fatalf("GetStatus() error = %v", err)
+	}
+	if status.Position == nil || status.Position.PanTilt == nil || status.Position.PanTilt.X != 0.1 {
+		t.Errorf("GetStatus() Position = %+v, want PanTilt.X = 0.1", status.Position)
+	}
+	if status.MoveStatus == nil || status.MoveStatus.PanTilt != "IDLE" {
+		t.Errorf("GetStatus() MoveStatus = %+v, want PanTilt = IDLE", status.MoveStatus)
+	}
+}
+
+func TestGetPresets(t *testing.T) {
+	body := `<GetPresetsResponse>
+        <Preset token="preset1">
+            <Name>Home</Name>
+            <PTZPosition>
+                <PanTilt x="1" y="2"/>
+                <Zoom x="3"/>
+            </PTZPosition>
+        </Preset>
+    </GetPresetsResponse>`
+	client := newPTZTestClient(t, newSOAPTestServer(t, body))
+
+	presets, err := client.GetPresets(context.Background(), "profile1")
+	if err != nil {
+		t.Fatalf("GetPresets() error = %v", err)
+	}
+	if len(presets) != 1 || presets[0].Token != "preset1" || presets[0].Name != "Home" {
+		t.Errorf("GetPresets() = %+v, want one preset {preset1 Home}", presets)
+	}
+}
+
+func TestGotoPreset(t *testing.T) {
+	client := newPTZTestClient(t, newSOAPTestServer(t, soapAckOnlyResponse))
+	if err := client.GotoPreset(context.Background(), "profile1", "preset1", nil); err != nil {
+		t.Errorf("GotoPreset() error = %v", err)
+	}
+}
+
+func TestSetPreset(t *testing.T) {
+	body := `<SetPresetResponse><PresetToken>preset42</PresetToken></SetPresetResponse>`
+	client := newPTZTestClient(t, newSOAPTestServer(t, body))
+
+	token, err := client.SetPreset(context.Background(), "profile1", "Home", "")
+	if err != nil {
+		t.Fatalf("SetPreset() error = %v", err)
+	}
+	if token != "preset42" {
+		t.Errorf("SetPreset() = %q, want %q", token, "preset42")
+	}
+}
+
+func TestRemovePreset(t *testing.T) {
+	client := newPTZTestClient(t, newSOAPTestServer(t, soapAckOnlyResponse))
+	if err := client.RemovePreset(context.Background(), "profile1", "preset1"); err != nil {
+		t.Errorf("RemovePreset() error = %v", err)
+	}
+}
+
+func TestGotoHomePosition(t *testing.T) {
+	client := newPTZTestClient(t, newSOAPTestServer(t, soapAckOnlyResponse))
+	if err := client.GotoHomePosition(context.Background(), "profile1", nil); err != nil {
+		t.Errorf("GotoHomePosition() error = %v", err)
+	}
+}
+
+func TestSetHomePosition(t *testing.T) {
+	client := newPTZTestClient(t, newSOAPTestServer(t, soapAckOnlyResponse))
+	if err := client.SetHomePosition(context.Background(), "profile1"); err != nil {
+		t.Errorf("SetHomePosition() error = %v", err)
+	}
+}
+
+func TestGetConfiguration(t *testing.T) {
+	body := `<GetConfigurationResponse>
+        <PTZConfiguration token="cfg1">
+            <Name>PTZ Config</Name>
+            <UseCount>1</UseCount>
+            <NodeToken>node1</NodeToken>
+        </PTZConfiguration>
+    </GetConfigurationResponse>`
+	client := newPTZTestClient(t, newSOAPTestServer(t, body))
+
+	cfg, err := client.GetConfiguration(context.Background(), "cfg1")
+	if err != nil {
+		t.Fatalf("GetConfiguration() error = %v", err)
+	}
+	if cfg.Token != "cfg1" || cfg.NodeToken != "node1" {
+		t.Errorf("GetConfiguration() = %+v, want Token=cfg1 NodeToken=node1", cfg)
+	}
+}
+
+func TestGetConfigurations(t *testing.T) {
+	body := `<GetConfigurationsResponse>
+        <PTZConfiguration token="cfg1">
+            <Name>PTZ Config</Name>
+            <UseCount>1</UseCount>
+            <NodeToken>node1</NodeToken>
+        </PTZConfiguration>
+    </GetConfigurationsResponse>`
+	client := newPTZTestClient(t, newSOAPTestServer(t, body))
+
+	cfgs, err := client.GetConfigurations(context.Background())
+	if err != nil {
+		t.Fatalf("GetConfigurations() error = %v", err)
+	}
+	if len(cfgs) != 1 || cfgs[0].Token != "cfg1" {
+		t.Errorf("GetConfigurations() = %+v, want one configuration with Token=cfg1", cfgs)
+	}
+}
 
 func TestConvertToPTZVectorXML(t *testing.T) {
 	if got := convertToPTZVectorXML(nil); got != nil {


### PR DESCRIPTION
## Summary
- `Client.mu` claimed to protect the type for concurrent use but only 4 of ~20+ touch points actually took it.
- `Initialize()` wrote `mediaEndpoint`/`ptzEndpoint`/`imagingEndpoint`/`eventEndpoint` with zero locking.
- `downloadWithBasicAuth`/`downloadWithDigestAuth` read `username`/`password` directly instead of through the already-locked `GetCredentials()`.
- Real races under `-race` for any caller sharing one long-lived `*Client` across goroutines (e.g. `Initialize()` racing a concurrent `GetProfiles()`).

## Fix
- Added locked `getPTZEndpoint()`/`getImagingEndpoint()` (mirroring the existing `getEventEndpoint` pattern) and locked the existing `getMediaEndpoint()`.
- `Initialize()` now takes `c.mu.Lock()` around the four field writes, after the network call (`GetCapabilities`) completes — never holds the lock across I/O.
- Both download helpers now call `c.GetCredentials()` instead of reading fields directly.
- No public API changes — fully backward compatible.

## Test plan
- [x] New `TestClientEndpointAndCredentialRace` (`client_test.go`) — 50 iterations × 6 goroutines (`Initialize`, the three new getters, `SetCredentials`, `GetCredentials`) against the existing `MockONVIFServer`.
- [x] `go test -race ./...` — all packages pass.
- [x] `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./...` — 0 issues.

Fixes #60