### PR TITLE
feat(server): implement minimal pull-point event service

### DIFF
--- a/server/device.go
+++ b/server/device.go
@@ -230,9 +230,9 @@ func (s *Server) HandleGetCapabilities(body interface{}) (interface{}, error) {
 	if s.config.SupportEvents {
 		capabilities.Events = &EventCapabilities{
 			XAddr:                         baseURL + "/events_service",
-			WSSubscriptionPolicySupport:   false,
-			WSPullPointSupport:            false,
-			WSPausableSubscriptionSupport: false,
+			WSSubscriptionPolicySupport:   false, // Filter/SubscriptionPolicy not implemented
+			WSPullPointSupport:            true,  // CreatePullPointSubscription/PullMessages/Renew/Unsubscribe implemented
+			WSPausableSubscriptionSupport: false, // pause/seek not implemented
 		}
 	}
 

--- a/server/errors.go
+++ b/server/errors.go
@@ -17,4 +17,12 @@ var (
 
 	// ErrPresetNotFound is returned when a preset is not found.
 	ErrPresetNotFound = errors.New("preset not found")
+
+	// ErrSubscriptionNotFound is returned when there is no active pull-point
+	// event subscription.
+	ErrSubscriptionNotFound = errors.New("no active pull-point subscription")
+
+	// ErrInvalidDuration is returned when an ISO-8601 duration string cannot
+	// be parsed.
+	ErrInvalidDuration = errors.New("invalid duration")
 )

--- a/server/event.go
+++ b/server/event.go
@@ -1,0 +1,254 @@
+package server
+
+import (
+	"encoding/xml"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// defaultSubscriptionDuration is used when a CreatePullPointSubscription or
+// Renew request omits its termination-time field.
+const defaultSubscriptionDuration = 10 * time.Minute
+
+// Event service SOAP message types.
+//
+// This is a minimal pull-point implementation: CreatePullPointSubscription,
+// PullMessages, Renew, and Unsubscribe only - enough to exercise this
+// repo's own client library end-to-end. There is no notification producer,
+// so PullMessages always returns zero messages; Seek,
+// SetEventSynchronizationPoint, GetEventServiceCapabilities,
+// GetEventProperties, and the EventBroker family are out of scope.
+
+// CreatePullPointSubscriptionRequest represents a CreatePullPointSubscription request.
+type CreatePullPointSubscriptionRequest struct {
+	XMLName                xml.Name `xml:"CreatePullPointSubscription"`
+	InitialTerminationTime string   `xml:"InitialTerminationTime"`
+}
+
+// CreatePullPointSubscriptionResponse represents a CreatePullPointSubscription response.
+type CreatePullPointSubscriptionResponse struct {
+	XMLName               xml.Name              `xml:"http://www.onvif.org/ver10/events/wsdl CreatePullPointSubscriptionResponse"`
+	SubscriptionReference SubscriptionReference `xml:"SubscriptionReference"`
+	CurrentTime           string                `xml:"CurrentTime"`
+	TerminationTime       string                `xml:"TerminationTime"`
+}
+
+// SubscriptionReference represents a WS-Eventing subscription reference.
+type SubscriptionReference struct {
+	Address string `xml:"Address"`
+}
+
+// PullMessagesRequest represents a PullMessages request.
+type PullMessagesRequest struct {
+	XMLName      xml.Name `xml:"PullMessages"`
+	Timeout      string   `xml:"Timeout"`
+	MessageLimit int      `xml:"MessageLimit"`
+}
+
+// PullMessagesResponse represents a PullMessages response.
+type PullMessagesResponse struct {
+	XMLName         xml.Name `xml:"http://www.onvif.org/ver10/events/wsdl PullMessagesResponse"`
+	CurrentTime     string   `xml:"CurrentTime"`
+	TerminationTime string   `xml:"TerminationTime"`
+}
+
+// RenewRequest represents a Renew request.
+type RenewRequest struct {
+	XMLName         xml.Name `xml:"Renew"`
+	TerminationTime string   `xml:"TerminationTime"`
+}
+
+// RenewResponse represents a Renew response.
+type RenewResponse struct {
+	XMLName         xml.Name `xml:"http://docs.oasis-open.org/wsn/b-2 RenewResponse"`
+	CurrentTime     string   `xml:"CurrentTime"`
+	TerminationTime string   `xml:"TerminationTime"`
+}
+
+// UnsubscribeResponse represents an Unsubscribe response.
+type UnsubscribeResponse struct {
+	XMLName xml.Name `xml:"http://docs.oasis-open.org/wsn/b-2 UnsubscribeResponse"`
+}
+
+// Event service handlers
+
+// HandleCreatePullPointSubscription handles CreatePullPointSubscription requests.
+// It replaces any existing subscription with a new one - this simulator
+// supports exactly one active pull-point subscription at a time (see
+// eventSubscription's doc comment for why).
+func (s *Server) HandleCreatePullPointSubscription(body interface{}) (interface{}, error) {
+	var req CreatePullPointSubscriptionRequest
+	if err := unmarshalBody(body, &req); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
+	duration := defaultSubscriptionDuration
+	if req.InitialTerminationTime != "" {
+		d, err := parseISODuration(req.InitialTerminationTime)
+		if err != nil {
+			return nil, fmt.Errorf("invalid InitialTerminationTime: %w", err)
+		}
+		duration = d
+	}
+
+	now := time.Now()
+	sub := &eventSubscription{terminationTime: now.Add(duration)}
+
+	s.subscriptionMu.Lock()
+	s.subscription = sub
+	s.scheduleExpiry(sub, duration)
+	s.subscriptionMu.Unlock()
+
+	return &CreatePullPointSubscriptionResponse{
+		SubscriptionReference: SubscriptionReference{Address: s.eventsServiceURL()},
+		CurrentTime:           now.UTC().Format(time.RFC3339),
+		TerminationTime:       sub.terminationTime.UTC().Format(time.RFC3339),
+	}, nil
+}
+
+// HandlePullMessages handles PullMessages requests. There is no
+// notification producer in this simulator, so a successful call always
+// returns zero messages.
+func (s *Server) HandlePullMessages(body interface{}) (interface{}, error) {
+	var req PullMessagesRequest
+	if err := unmarshalBody(body, &req); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
+	s.subscriptionMu.RLock()
+	sub := s.subscription
+	s.subscriptionMu.RUnlock()
+
+	if sub == nil {
+		return nil, ErrSubscriptionNotFound
+	}
+
+	return &PullMessagesResponse{
+		CurrentTime:     time.Now().UTC().Format(time.RFC3339),
+		TerminationTime: sub.terminationTime.UTC().Format(time.RFC3339),
+	}, nil
+}
+
+// HandleRenew handles Renew requests, extending the active subscription's
+// termination time.
+func (s *Server) HandleRenew(body interface{}) (interface{}, error) {
+	var req RenewRequest
+	if err := unmarshalBody(body, &req); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
+	duration := defaultSubscriptionDuration
+	if req.TerminationTime != "" {
+		d, err := parseISODuration(req.TerminationTime)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TerminationTime: %w", err)
+		}
+		duration = d
+	}
+
+	s.subscriptionMu.Lock()
+	defer s.subscriptionMu.Unlock()
+
+	sub := s.subscription
+	if sub == nil {
+		return nil, ErrSubscriptionNotFound
+	}
+
+	now := time.Now()
+	sub.terminationTime = now.Add(duration)
+	s.scheduleExpiry(sub, duration)
+
+	return &RenewResponse{
+		CurrentTime:     now.UTC().Format(time.RFC3339),
+		TerminationTime: sub.terminationTime.UTC().Format(time.RFC3339),
+	}, nil
+}
+
+// HandleUnsubscribe handles Unsubscribe requests, immediately terminating
+// the active subscription. Unsubscribe carries no request fields, so there
+// is nothing to decode from body.
+func (s *Server) HandleUnsubscribe(_ interface{}) (interface{}, error) {
+	s.subscriptionMu.Lock()
+	defer s.subscriptionMu.Unlock()
+
+	if s.subscription == nil {
+		return nil, ErrSubscriptionNotFound
+	}
+	if s.subscription.expiryTimer != nil {
+		s.subscription.expiryTimer.Stop()
+	}
+	s.subscription = nil
+
+	return &UnsubscribeResponse{}, nil
+}
+
+// scheduleExpiry stops any expiry timer already pending for sub and
+// schedules a new one that clears s.subscription after delay - but only if
+// s.subscription is still sub by the time the timer fires. That
+// pointer-identity check matters because CreatePullPointSubscription
+// replaces the whole *eventSubscription rather than mutating one in place
+// (unlike PTZState's settleTimer, which mutates fields inside the same
+// long-lived struct): without it, a very-late-firing timer from a
+// since-replaced subscription could nil out a brand-new one. Must be
+// called with s.subscriptionMu held, since it mutates sub.expiryTimer.
+func (s *Server) scheduleExpiry(sub *eventSubscription, delay time.Duration) {
+	if sub.expiryTimer != nil {
+		sub.expiryTimer.Stop()
+	}
+	sub.expiryTimer = time.AfterFunc(delay, func() {
+		s.subscriptionMu.Lock()
+		defer s.subscriptionMu.Unlock()
+		if s.subscription == sub {
+			s.subscription = nil
+		}
+	})
+}
+
+// eventsServiceURL builds the URL this server's events service is reachable
+// at, using the same host-normalization and base-URL construction as
+// HandleGetCapabilities (device.go).
+func (s *Server) eventsServiceURL() string {
+	host := s.config.Host
+	if host == defaultHost || host == "" {
+		host = defaultHostname
+	}
+
+	return fmt.Sprintf("http://%s:%d%s/events_service", host, s.config.Port, s.config.BasePath)
+}
+
+// isoDurationPattern matches the limited ISO-8601 duration grammar this
+// repo's own client ever produces (event.go's formatDuration): "PT<n>S",
+// "PT<n>M", or "PT<n>M<n>S". No other producer of these values exists to
+// test against, so a general ISO-8601 duration parser is out of scope.
+var isoDurationPattern = regexp.MustCompile(`^PT(?:(\d+)M)?(?:(\d+)S)?$`)
+
+// parseISODuration parses an ISO-8601 duration string in the grammar
+// described by isoDurationPattern.
+func parseISODuration(s string) (time.Duration, error) {
+	m := isoDurationPattern.FindStringSubmatch(s)
+	if m == nil || (m[1] == "" && m[2] == "") {
+		return 0, fmt.Errorf("%w: %s", ErrInvalidDuration, s)
+	}
+
+	var d time.Duration
+
+	if m[1] != "" {
+		minutes, err := strconv.Atoi(m[1])
+		if err != nil {
+			return 0, fmt.Errorf("%w: %s", ErrInvalidDuration, s)
+		}
+		d += time.Duration(minutes) * time.Minute
+	}
+
+	if m[2] != "" {
+		seconds, err := strconv.Atoi(m[2])
+		if err != nil {
+			return 0, fmt.Errorf("%w: %s", ErrInvalidDuration, s)
+		}
+		d += time.Duration(seconds) * time.Second
+	}
+
+	return d, nil
+}

--- a/server/event_test.go
+++ b/server/event_test.go
@@ -1,0 +1,297 @@
+package server
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+const (
+	testDuration1Sec = "PT1S"
+	testDuration5Sec = "PT5S"
+	testDuration1Min = "PT1M"
+)
+
+func TestHandleCreatePullPointSubscriptionDefaultDuration(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	before := time.Now()
+
+	resp, err := srv.HandleCreatePullPointSubscription(CreatePullPointSubscriptionRequest{})
+	if err != nil {
+		t.Fatalf("HandleCreatePullPointSubscription() error = %v", err)
+	}
+
+	createResp, ok := resp.(*CreatePullPointSubscriptionResponse)
+	if !ok {
+		t.Fatalf("Response is not CreatePullPointSubscriptionResponse, got %T", resp)
+	}
+
+	if createResp.SubscriptionReference.Address == "" {
+		t.Error("expected a non-empty SubscriptionReference.Address")
+	}
+
+	term, err := time.Parse(time.RFC3339, createResp.TerminationTime)
+	if err != nil {
+		t.Fatalf("TerminationTime is not RFC3339: %v", err)
+	}
+	if diff := term.Sub(before); diff < defaultSubscriptionDuration-time.Second || diff > defaultSubscriptionDuration+time.Second {
+		t.Errorf("expected TerminationTime ~%v after now, got diff %v", defaultSubscriptionDuration, diff)
+	}
+
+	srv.subscriptionMu.RLock()
+	sub := srv.subscription
+	srv.subscriptionMu.RUnlock()
+	if sub == nil {
+		t.Error("expected srv.subscription to be populated")
+	}
+}
+
+func TestHandleCreatePullPointSubscriptionExplicitDuration(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	before := time.Now()
+
+	resp, err := srv.HandleCreatePullPointSubscription(CreatePullPointSubscriptionRequest{
+		InitialTerminationTime: testDuration5Sec,
+	})
+	if err != nil {
+		t.Fatalf("HandleCreatePullPointSubscription() error = %v", err)
+	}
+
+	createResp, ok := resp.(*CreatePullPointSubscriptionResponse)
+	if !ok {
+		t.Fatalf("Response is not CreatePullPointSubscriptionResponse, got %T", resp)
+	}
+
+	term, err := time.Parse(time.RFC3339, createResp.TerminationTime)
+	if err != nil {
+		t.Fatalf("TerminationTime is not RFC3339: %v", err)
+	}
+	if diff := term.Sub(before); diff < 4*time.Second || diff > 6*time.Second {
+		t.Errorf("expected TerminationTime ~5s after now, got diff %v", diff)
+	}
+}
+
+func TestHandleCreatePullPointSubscriptionReplacesExisting(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if _, err := srv.HandleCreatePullPointSubscription(CreatePullPointSubscriptionRequest{InitialTerminationTime: testDuration1Sec}); err != nil {
+		t.Fatalf("first HandleCreatePullPointSubscription() error = %v", err)
+	}
+
+	srv.subscriptionMu.RLock()
+	first := srv.subscription
+	srv.subscriptionMu.RUnlock()
+
+	if _, err := srv.HandleCreatePullPointSubscription(CreatePullPointSubscriptionRequest{InitialTerminationTime: testDuration1Min}); err != nil {
+		t.Fatalf("second HandleCreatePullPointSubscription() error = %v", err)
+	}
+
+	srv.subscriptionMu.RLock()
+	second := srv.subscription
+	srv.subscriptionMu.RUnlock()
+
+	if first == second {
+		t.Fatalf("expected the second call to replace the subscription pointer")
+	}
+
+	// Wait past the first subscription's 1s expiry. The pointer-identity
+	// guard in scheduleExpiry must stop the stale timer from clearing the
+	// second (still-active, 1-minute) subscription.
+	time.Sleep(1500 * time.Millisecond)
+
+	srv.subscriptionMu.RLock()
+	current := srv.subscription
+	srv.subscriptionMu.RUnlock()
+
+	if current == nil {
+		t.Errorf("expected the second subscription to still be active; a stale timer from the first cleared it")
+	}
+}
+
+func TestHandlePullMessagesNoActiveSubscription(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if _, err := srv.HandlePullMessages(PullMessagesRequest{Timeout: testDuration1Sec, MessageLimit: 10}); !errors.Is(err, ErrSubscriptionNotFound) {
+		t.Errorf("expected ErrSubscriptionNotFound, got %v", err)
+	}
+}
+
+func TestHandlePullMessagesReturnsEmpty(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if _, err := srv.HandleCreatePullPointSubscription(CreatePullPointSubscriptionRequest{}); err != nil {
+		t.Fatalf("HandleCreatePullPointSubscription() error = %v", err)
+	}
+
+	resp, err := srv.HandlePullMessages(PullMessagesRequest{Timeout: testDuration1Sec, MessageLimit: 10})
+	if err != nil {
+		t.Fatalf("HandlePullMessages() error = %v", err)
+	}
+
+	if _, ok := resp.(*PullMessagesResponse); !ok {
+		t.Fatalf("expected *PullMessagesResponse, got %T", resp)
+	}
+}
+
+func TestHandleRenewExtendsTerminationTime(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	createResp, err := srv.HandleCreatePullPointSubscription(CreatePullPointSubscriptionRequest{InitialTerminationTime: testDuration5Sec})
+	if err != nil {
+		t.Fatalf("HandleCreatePullPointSubscription() error = %v", err)
+	}
+	originalTerm, err := time.Parse(time.RFC3339, createResp.(*CreatePullPointSubscriptionResponse).TerminationTime)
+	if err != nil {
+		t.Fatalf("failed to parse original TerminationTime: %v", err)
+	}
+
+	renewResp, err := srv.HandleRenew(RenewRequest{TerminationTime: testDuration1Min})
+	if err != nil {
+		t.Fatalf("HandleRenew() error = %v", err)
+	}
+
+	newTerm, err := time.Parse(time.RFC3339, renewResp.(*RenewResponse).TerminationTime)
+	if err != nil {
+		t.Fatalf("failed to parse renewed TerminationTime: %v", err)
+	}
+
+	if !newTerm.After(originalTerm) {
+		t.Errorf("expected renewed TerminationTime %v to be after original %v", newTerm, originalTerm)
+	}
+}
+
+func TestHandleRenewNoActiveSubscription(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if _, err := srv.HandleRenew(RenewRequest{TerminationTime: testDuration1Min}); !errors.Is(err, ErrSubscriptionNotFound) {
+		t.Errorf("expected ErrSubscriptionNotFound, got %v", err)
+	}
+}
+
+func TestHandleUnsubscribeClearsSubscription(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if _, err := srv.HandleCreatePullPointSubscription(CreatePullPointSubscriptionRequest{}); err != nil {
+		t.Fatalf("HandleCreatePullPointSubscription() error = %v", err)
+	}
+
+	if _, err := srv.HandleUnsubscribe(nil); err != nil {
+		t.Fatalf("HandleUnsubscribe() error = %v", err)
+	}
+
+	srv.subscriptionMu.RLock()
+	sub := srv.subscription
+	srv.subscriptionMu.RUnlock()
+	if sub != nil {
+		t.Error("expected srv.subscription to be nil after Unsubscribe")
+	}
+
+	if _, err := srv.HandlePullMessages(PullMessagesRequest{Timeout: testDuration1Sec, MessageLimit: 10}); !errors.Is(err, ErrSubscriptionNotFound) {
+		t.Errorf("expected PullMessages after Unsubscribe to fail with ErrSubscriptionNotFound, got %v", err)
+	}
+}
+
+func TestHandleUnsubscribeNoActiveSubscription(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if _, err := srv.HandleUnsubscribe(nil); !errors.Is(err, ErrSubscriptionNotFound) {
+		t.Errorf("expected ErrSubscriptionNotFound, got %v", err)
+	}
+}
+
+// TestEventSubscriptionExpires lets a subscription's expiry timer actually
+// fire (with a short custom delay, rather than waiting out the real
+// 10-minute default) and verifies subsequent PullMessages/Renew calls see
+// it as gone. Mirrors TestScheduleSettleFires in integration_test.go.
+func TestEventSubscriptionExpires(t *testing.T) {
+	config := createTestConfig()
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	sub := &eventSubscription{terminationTime: time.Now().Add(10 * time.Millisecond)}
+	srv.subscriptionMu.Lock()
+	srv.subscription = sub
+	srv.scheduleExpiry(sub, 10*time.Millisecond)
+	srv.subscriptionMu.Unlock()
+
+	time.Sleep(150 * time.Millisecond)
+
+	if _, err := srv.HandlePullMessages(PullMessagesRequest{Timeout: testDuration1Sec, MessageLimit: 10}); !errors.Is(err, ErrSubscriptionNotFound) {
+		t.Errorf("expected the expiry timer to have cleared the subscription, got %v", err)
+	}
+}
+
+func TestParseISODuration(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{input: testDuration5Sec, want: 5 * time.Second},
+		{input: testDuration1Min, want: 1 * time.Minute},
+		{input: "PT1M30S", want: 90 * time.Second},
+		{input: "", wantErr: true},
+		{input: "PT", wantErr: true},
+		{input: "garbage", wantErr: true},
+		{input: "P1D", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseISODuration(tt.input)
+			if tt.wantErr {
+				if !errors.Is(err, ErrInvalidDuration) {
+					t.Errorf("parseISODuration(%q): expected ErrInvalidDuration, got %v", tt.input, err)
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseISODuration(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseISODuration(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/integration_test.go
+++ b/server/integration_test.go
@@ -14,6 +14,44 @@ import (
 	internalsoap "github.com/0x524a/onvif-go/internal/soap"
 )
 
+// readPTZState returns a snapshot of the PTZ state for profileToken, taken
+// while holding srv.ptzMu.
+//
+// GetPTZState returns a *pointer* to shared mutable state and releases the
+// lock before the caller reads any field, so reading those fields directly
+// races with scheduleSettle's timer callback, which writes them under
+// ptzMu. Every PTZ move leaves such a timer pending past the end of the
+// test that started it, so these reads must snapshot under the lock.
+func readPTZState(t *testing.T, srv *Server, profileToken string) (PTZState, bool) {
+	t.Helper()
+
+	srv.ptzMu.RLock()
+	defer srv.ptzMu.RUnlock()
+
+	state, ok := srv.ptzState[profileToken]
+	if !ok {
+		return PTZState{}, false
+	}
+
+	return *state, true
+}
+
+// readImagingState is readPTZState's imaging counterpart, for the same
+// pointer-escapes-the-lock reason.
+func readImagingState(t *testing.T, srv *Server, videoSourceToken string) (ImagingState, bool) {
+	t.Helper()
+
+	srv.imagingMu.RLock()
+	defer srv.imagingMu.RUnlock()
+
+	state, ok := srv.imagingState[videoSourceToken]
+	if !ok {
+		return ImagingState{}, false
+	}
+
+	return *state, true
+}
+
 // TestServeHTTPEndToEndContinuousMove is a regression test for a bug where
 // every parameterized server operation always received a nil request body
 // (originsoap.Body.Content was interface{}, which encoding/xml cannot
@@ -58,7 +96,7 @@ func TestServeHTTPEndToEndContinuousMove(t *testing.T) {
 		t.Fatalf("ContinuousMove over the real wire path failed: %v", err)
 	}
 
-	state, ok := srv.GetPTZState(profileToken)
+	state, ok := readPTZState(t, srv, profileToken)
 	if !ok {
 		t.Fatalf("expected PTZ state for profile %q", profileToken)
 	}
@@ -138,7 +176,7 @@ func TestPTZSettleTimerCancelledOnRepeatedMove(t *testing.T) {
 
 	time.Sleep(300 * time.Millisecond)
 
-	state, ok := srv.GetPTZState(profileToken)
+	state, ok := readPTZState(t, srv, profileToken)
 	if !ok {
 		t.Fatalf("expected PTZ state for profile %q", profileToken)
 	}
@@ -170,7 +208,7 @@ func TestPTZStopCancelsSettleTimer(t *testing.T) {
 		t.Fatalf("HandleAbsoluteMove() error = %v", err)
 	}
 
-	state, ok := srv.GetPTZState(profileToken)
+	state, ok := readPTZState(t, srv, profileToken)
 	if !ok {
 		t.Fatalf("expected PTZ state for profile %q", profileToken)
 	}
@@ -182,6 +220,12 @@ func TestPTZStopCancelsSettleTimer(t *testing.T) {
 		t.Fatalf("HandleStop() error = %v", err)
 	}
 
+	// Re-snapshot: the first snapshot is a copy, so it still holds the
+	// pre-Stop timer pointer and would not reflect Stop clearing it.
+	state, ok = readPTZState(t, srv, profileToken)
+	if !ok {
+		t.Fatalf("expected PTZ state for profile %q", profileToken)
+	}
 	if state.settleTimer != nil {
 		t.Errorf("expected Stop to cancel and clear the pending settle timer, it's still set")
 	}
@@ -215,7 +259,7 @@ func TestHandleRelativeMove(t *testing.T) {
 		t.Fatalf("expected *RelativeMoveResponse, got %T", resp)
 	}
 
-	state, ok := srv.GetPTZState(profileToken)
+	state, ok := readPTZState(t, srv, profileToken)
 	if !ok {
 		t.Fatalf("expected PTZ state for profile %q", profileToken)
 	}
@@ -254,7 +298,7 @@ func TestHandleMove(t *testing.T) {
 		t.Fatalf("expected *MoveResponse, got %T", resp)
 	}
 
-	state, ok := srv.GetImagingState(videoSourceToken)
+	state, ok := readImagingState(t, srv, videoSourceToken)
 	if !ok {
 		t.Fatalf("expected imaging state for video source %q", videoSourceToken)
 	}
@@ -298,22 +342,24 @@ func TestScheduleSettleFires(t *testing.T) {
 	}
 	profileToken := config.Profiles[0].Token
 
-	state, ok := srv.GetPTZState(profileToken)
+	// The pointer is needed to hand the live state to scheduleSettle; the
+	// mutations below are done under ptzMu, as scheduleSettle requires.
+	statePtr, ok := srv.GetPTZState(profileToken)
 	if !ok {
 		t.Fatalf("expected PTZ state for profile %q", profileToken)
 	}
 
 	srv.ptzMu.Lock()
-	state.Moving = true
-	state.PanMoving = true
-	state.TiltMoving = true
-	state.ZoomMoving = true
-	srv.scheduleSettle(state, 10*time.Millisecond)
+	statePtr.Moving = true
+	statePtr.PanMoving = true
+	statePtr.TiltMoving = true
+	statePtr.ZoomMoving = true
+	srv.scheduleSettle(statePtr, 10*time.Millisecond)
 	srv.ptzMu.Unlock()
 
 	time.Sleep(150 * time.Millisecond)
 
-	state, ok = srv.GetPTZState(profileToken)
+	state, ok := readPTZState(t, srv, profileToken)
 	if !ok {
 		t.Fatalf("expected PTZ state for profile %q", profileToken)
 	}

--- a/server/integration_test.go
+++ b/server/integration_test.go
@@ -3,12 +3,14 @@ package server
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
 
+	onvif "github.com/0x524a/onvif-go"
 	internalsoap "github.com/0x524a/onvif-go/internal/soap"
 )
 
@@ -317,5 +319,100 @@ func TestScheduleSettleFires(t *testing.T) {
 	}
 	if state.Moving || state.PanMoving || state.TiltMoving || state.ZoomMoving {
 		t.Errorf("expected the settle timer to have cleared all Moving flags, got %+v", state)
+	}
+}
+
+// TestServeHTTPEndToEndEventSubscriptionLifecycle drives the real
+// onvif.Client's pull-point event methods (CreatePullPointSubscription ->
+// PullMessages -> RenewSubscription -> Unsubscribe -> PullMessages again)
+// through a real HTTP round trip against registerEventService, for #62.
+//
+// Unlike GetStreamURI/GetSnapshotURI (whose returned URIs are just
+// descriptive - existing e2e tests never dereference them), PullMessages/
+// RenewSubscription/Unsubscribe all call back on the server-returned
+// SubscriptionReference.Address, and that address is built from
+// s.config.Host/Port (eventsServiceURL, matching every other service's
+// baseURL construction). createTestConfig() hardcodes Port: 8080, which
+// httptest.NewServer's usual random port would not match, so the
+// subscription reference the client calls back on would point nowhere.
+// Fixed here, in the test, not in the implementation: bind a listener on
+// 127.0.0.1:0 first, read back its actual port, set config.Port to that
+// before constructing the Server, then hand the listener to
+// httptest.NewUnstartedServer - so the config the server advertises
+// through and the address it's actually reachable at agree, exactly as
+// they would for a real deployment.
+func TestServeHTTPEndToEndEventSubscriptionLifecycle(t *testing.T) {
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() failed: %v", err)
+	}
+
+	config := createTestConfig()
+	config.SupportEvents = true
+	config.Host = "127.0.0.1"
+	config.Port = listener.Addr().(*net.TCPAddr).Port
+
+	srv, err := New(config)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	srv.registerEventService(mux)
+
+	testServer := httptest.NewUnstartedServer(mux)
+	_ = testServer.Listener.Close()
+	testServer.Listener = listener
+	testServer.Start()
+	defer testServer.Close()
+
+	client, err := onvif.NewClient(
+		testServer.URL+config.BasePath+"/events_service",
+		onvif.WithCredentials(config.Username, config.Password),
+		onvif.WithHTTPClient(testServer.Client()),
+	)
+	if err != nil {
+		t.Fatalf("onvif.NewClient() failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	sub, err := client.CreatePullPointSubscription(ctx, "", nil, "")
+	if err != nil {
+		t.Fatalf("CreatePullPointSubscription over the real wire path failed: %v", err)
+	}
+	if sub.SubscriptionReference == "" {
+		t.Fatal("expected a non-empty SubscriptionReference")
+	}
+
+	msgs, err := client.PullMessages(ctx, sub.SubscriptionReference, 2*time.Second, 10)
+	if err != nil {
+		t.Fatalf("PullMessages over the real wire path failed: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("expected zero notification messages from the simulator, got %d", len(msgs))
+	}
+
+	beforeRenew := time.Now()
+
+	_, newTerm, err := client.RenewSubscription(ctx, sub.SubscriptionReference, 30*time.Second)
+	if err != nil {
+		t.Fatalf("RenewSubscription over the real wire path failed: %v", err)
+	}
+	// Renew requests a fresh 30s duration from now, which is shorter than
+	// CreatePullPointSubscription's 10-minute default - so the correct
+	// check is against the requested duration, not against sub.TerminationTime.
+	if diff := newTerm.Sub(beforeRenew); diff < 25*time.Second || diff > 35*time.Second {
+		t.Errorf("expected renewed termination time ~30s from now, got diff %v", diff)
+	}
+
+	if err := client.Unsubscribe(ctx, sub.SubscriptionReference); err != nil {
+		t.Fatalf("Unsubscribe over the real wire path failed: %v", err)
+	}
+
+	if _, err := client.PullMessages(ctx, sub.SubscriptionReference, 2*time.Second, 10); err == nil {
+		t.Error("expected PullMessages after Unsubscribe to fail, got nil error")
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -115,6 +115,10 @@ func (s *Server) Start(ctx context.Context) error {
 		s.registerImagingService(mux)
 	}
 
+	if s.config.SupportEvents {
+		s.registerEventService(mux)
+	}
+
 	// Add snapshot endpoint
 	mux.HandleFunc(s.config.BasePath+"/snapshot", s.handleSnapshot)
 
@@ -234,6 +238,19 @@ func (s *Server) registerImagingService(mux *http.ServeMux) {
 	handler.RegisterHandler("Move", s.HandleMove)
 
 	mux.Handle(s.config.BasePath+"/imaging_service", handler)
+}
+
+// registerEventService registers the event service handler.
+func (s *Server) registerEventService(mux *http.ServeMux) {
+	handler := soap.NewHandler(s.config.Username, s.config.Password)
+
+	// Register event service handlers
+	handler.RegisterHandler("CreatePullPointSubscription", s.HandleCreatePullPointSubscription)
+	handler.RegisterHandler("PullMessages", s.HandlePullMessages)
+	handler.RegisterHandler("Renew", s.HandleRenew)
+	handler.RegisterHandler("Unsubscribe", s.HandleUnsubscribe)
+
+	mux.Handle(s.config.BasePath+"/events_service", handler)
 }
 
 // handleSnapshot handles HTTP snapshot requests.

--- a/server/types.go
+++ b/server/types.go
@@ -211,6 +211,11 @@ type Server struct {
 	// Server instances in one process don't serialize through one lock.
 	ptzMu     sync.RWMutex
 	imagingMu sync.RWMutex
+
+	// subscription holds the server's single implicit pull-point event
+	// subscription (nil when none is active). Guarded by subscriptionMu.
+	subscription   *eventSubscription
+	subscriptionMu sync.RWMutex
 }
 
 // PTZState represents the current PTZ state.
@@ -226,6 +231,22 @@ type PTZState struct {
 	// Moving/PanMoving/TiltMoving/ZoomMoving flags once a simulated move
 	// settles. Guarded by the owning Server's ptzMu.
 	settleTimer *time.Timer
+}
+
+// eventSubscription represents the server's single implicit pull-point
+// event subscription. There is no per-request subscription identifier in
+// the ONVIF wire format for PullMessages/Renew/Unsubscribe - the callback
+// URL itself is the only thing that identifies a subscription - so this
+// simulator supports exactly one active subscription at a time, replaced
+// wholesale by a new CreatePullPointSubscription call. Guarded by the
+// owning Server's subscriptionMu.
+type eventSubscription struct {
+	terminationTime time.Time
+
+	// expiryTimer, when non-nil, is the pending timer that will clear the
+	// owning Server's subscription field once this subscription's
+	// termination time elapses. Mirrors PTZState.settleTimer.
+	expiryTimer *time.Timer
 }
 
 // ImagingState represents the current imaging settings state.


### PR DESCRIPTION
## Summary
- `Config.SupportEvents` advertised an `/events_service` endpoint via `GetCapabilities`, but no such handler was ever registered — every request 404'd regardless of the flag.
- Rather than just stopping the false advertisement, this implements a real minimal pull-point event service so the simulator actually supports it and this repo's own client library has something to test against end-to-end.

## Scope
Exactly `CreatePullPointSubscription`, `PullMessages`, `Renew`, `Unsubscribe` — the four client methods this gap affected. No `Seek`/pause, no EventBroker family, no simulated event generation (`PullMessages` against an empty simulator legitimately returns zero messages every time — protocol plumbing, not simulated camera behavior).

## Design notes
- **Single implicit subscription**: `PullMessages`/`Renew`/`Unsubscribe` carry no subscription identifier anywhere in the wire format — the callback URL itself is the only thing that identifies a subscription, and the SOAP handler signature (`func(body interface{})`) has no access to the inbound request to disambiguate multiple routes. One subscription slot, replaced wholesale by a new `CreatePullPointSubscription` call, is the correct minimal design given this constraint.
- **Expiry**: a cancellable `time.AfterFunc` timer modeled directly on `PTZState.settleTimer`/`scheduleSettle`, including the same pointer-identity guard against a stale timer clobbering a subsequently-created subscription.
- **Duration parsing**: no ISO-8601 duration parser existed anywhere in the repo; added one scoped to exactly the grammar this repo's own client (`formatDuration`) ever produces (`PT<n>S`/`PT<n>M`/`PT<n>M<n>S`).
- `GetCapabilities`' `WSPullPointSupport` flipped to `true` now that it's genuinely functional (confirmed nothing in the client branches on this flag's value, so it's a pure accuracy fix).

## Test plan
- [x] New `server/event_test.go` — create/renew/unsubscribe/expiry unit tests, including the pointer-identity guard and duration parsing.
- [x] New end-to-end test in `server/integration_test.go` driving the real `onvif.Client` through the full subscription lifecycle over real HTTP (binds a real listener and pins `Config.Port` to it, since the returned `SubscriptionReference.Address` is actually dereferenced by follow-up calls, unlike other services' descriptive-only URIs).
- [x] `go test -race ./...` — all packages pass.
- [x] `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./...` — 0 issues.

Fixes #62