### PR TITLE
feat(client): distinguish ErrNotInitialized from ErrServiceNotSupported in PTZ and Imaging

### DIFF
--- a/client.go
+++ b/client.go
@@ -43,6 +43,13 @@ type Client struct {
 	ptzEndpoint     string
 	imagingEndpoint string
 	eventEndpoint   string
+
+	// initialized reports whether Initialize has successfully fetched the
+	// device's capabilities at least once. It distinguishes "this client has
+	// not looked for the service yet" from "the device reported it does not
+	// have the service", which are indistinguishable from an empty endpoint
+	// field alone. Guarded by mu.
+	initialized bool
 }
 
 // ClientOption is a functional option for configuring the Client.
@@ -194,7 +201,18 @@ func (c *Client) fixLocalhostURL(serviceURL string) string {
 	return serviceURL
 }
 
-// Initialize discovers and initializes service endpoints.
+// Initialize discovers and initializes service endpoints by fetching the
+// device's capabilities.
+//
+// Services differ in how they behave before Initialize has succeeded:
+//
+//   - PTZ and Imaging operations require it. Until it succeeds they return
+//     ErrNotInitialized, because the client has no way to know whether the
+//     device supports those services. Once it succeeds, a service the device
+//     did not report yields ErrServiceNotSupported instead.
+//   - Media and Events operations fall back to the device endpoint, which
+//     many cameras also serve those operations on, so they often work
+//     without Initialize.
 func (c *Client) Initialize(ctx context.Context) error {
 	// Get device information and capabilities
 	capabilities, err := c.GetCapabilities(ctx)
@@ -217,6 +235,10 @@ func (c *Client) Initialize(ctx context.Context) error {
 	if capabilities.Events != nil && capabilities.Events.XAddr != "" {
 		c.eventEndpoint = c.fixLocalhostURL(capabilities.Events.XAddr)
 	}
+	// Set last, in the same critical section as the endpoints it describes:
+	// from here on an empty PTZ/Imaging endpoint means the device reported no
+	// such service, not that nobody has asked yet.
+	c.initialized = true
 	c.mu.Unlock()
 
 	return nil

--- a/client_test.go
+++ b/client_test.go
@@ -1231,11 +1231,11 @@ func TestClientEndpointAndCredentialRace(t *testing.T) {
 		}()
 		go func() {
 			defer wg.Done()
-			_ = client.getPTZEndpoint()
+			_, _ = client.getPTZEndpoint()
 		}()
 		go func() {
 			defer wg.Done()
-			_ = client.getImagingEndpoint()
+			_, _ = client.getImagingEndpoint()
 		}()
 		go func(n int) {
 			defer wg.Done()

--- a/errors.go
+++ b/errors.go
@@ -30,7 +30,11 @@ var (
 	// ErrInvalidParameter is returned when a parameter is invalid.
 	ErrInvalidParameter = errors.New("invalid parameter")
 
-	// ErrNotInitialized is returned when the client is not initialized.
+	// ErrNotInitialized is returned by PTZ and Imaging operations when
+	// Initialize has not successfully run, so the client does not yet know
+	// whether the device offers the service. It is a recoverable client-state
+	// problem - call Initialize and retry - and is deliberately distinct from
+	// ErrServiceNotSupported, which reports a permanent device limitation.
 	ErrNotInitialized = errors.New("client not initialized")
 
 	// ErrNoProbeMatches is returned when no probe matches are found during discovery.

--- a/imaging.go
+++ b/imaging.go
@@ -11,21 +11,38 @@ import (
 // Imaging service namespace.
 const imagingNamespace = "http://www.onvif.org/ver20/imaging/wsdl"
 
-// getImagingEndpoint returns the imaging endpoint.
-func (c *Client) getImagingEndpoint() string {
+// getImagingEndpoint returns the discovered Imaging service endpoint.
+//
+// It reports ErrNotInitialized or ErrServiceNotSupported on an unknown
+// endpoint for the same reasons, and with the same caller contract, as
+// getPTZEndpoint - see its documentation.
+//
+// Every Imaging operation goes through here. Three of them previously fell
+// back to the device endpoint while the other four returned an error, so the
+// same client state produced a working call or a "not supported" error
+// depending only on which Imaging method you happened to reach for.
+func (c *Client) getImagingEndpoint() (string, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return c.imagingEndpoint
+	if c.imagingEndpoint == "" {
+		if !c.initialized {
+			return "", ErrNotInitialized
+		}
+
+		return "", ErrServiceNotSupported
+	}
+
+	return c.imagingEndpoint, nil
 }
 
 // GetImagingSettings retrieves imaging settings for a video source.
 //
 //nolint:funlen // GetImagingSettings has many statements due to parsing complex imaging settings
 func (c *Client) GetImagingSettings(ctx context.Context, videoSourceToken string) (*ImagingSettings, error) {
-	endpoint := c.getImagingEndpoint()
-	if endpoint == "" {
-		endpoint = c.endpoint
+	endpoint, err := c.getImagingEndpoint()
+	if err != nil {
+		return nil, err
 	}
 
 	type GetImagingSettings struct {
@@ -155,9 +172,9 @@ func (c *Client) GetImagingSettings(ctx context.Context, videoSourceToken string
 func (c *Client) SetImagingSettings(
 	ctx context.Context, videoSourceToken string, settings *ImagingSettings, forcePersistence bool,
 ) error {
-	endpoint := c.getImagingEndpoint()
-	if endpoint == "" {
-		endpoint = c.endpoint
+	endpoint, err := c.getImagingEndpoint()
+	if err != nil {
+		return err
 	}
 
 	type SetImagingSettings struct {
@@ -305,9 +322,9 @@ func (c *Client) SetImagingSettings(
 
 // Move performs a focus move operation.
 func (c *Client) Move(ctx context.Context, videoSourceToken string, focus *FocusMove) error {
-	endpoint := c.getImagingEndpoint()
-	if endpoint == "" {
-		endpoint = c.endpoint
+	endpoint, err := c.getImagingEndpoint()
+	if err != nil {
+		return err
 	}
 
 	type Move struct {
@@ -368,9 +385,9 @@ type FocusMove struct {
 
 // GetOptions retrieves imaging options for a video source.
 func (c *Client) GetOptions(ctx context.Context, videoSourceToken string) (*ImagingOptions, error) {
-	endpoint := c.getImagingEndpoint()
-	if endpoint == "" {
-		return nil, ErrServiceNotSupported
+	endpoint, err := c.getImagingEndpoint()
+	if err != nil {
+		return nil, err
 	}
 
 	type GetOptions struct {
@@ -465,9 +482,9 @@ func (c *Client) GetOptions(ctx context.Context, videoSourceToken string) (*Imag
 
 // GetMoveOptions retrieves imaging move options for focus.
 func (c *Client) GetMoveOptions(ctx context.Context, videoSourceToken string) (*MoveOptions, error) {
-	endpoint := c.getImagingEndpoint()
-	if endpoint == "" {
-		return nil, ErrServiceNotSupported
+	endpoint, err := c.getImagingEndpoint()
+	if err != nil {
+		return nil, err
 	}
 
 	type GetMoveOptions struct {
@@ -564,9 +581,9 @@ func (c *Client) GetMoveOptions(ctx context.Context, videoSourceToken string) (*
 
 // StopFocus stops focus movement.
 func (c *Client) StopFocus(ctx context.Context, videoSourceToken string) error {
-	endpoint := c.getImagingEndpoint()
-	if endpoint == "" {
-		return ErrServiceNotSupported
+	endpoint, err := c.getImagingEndpoint()
+	if err != nil {
+		return err
 	}
 
 	type Stop struct {
@@ -592,9 +609,9 @@ func (c *Client) StopFocus(ctx context.Context, videoSourceToken string) error {
 
 // GetImagingStatus retrieves imaging status.
 func (c *Client) GetImagingStatus(ctx context.Context, videoSourceToken string) (*ImagingStatus, error) {
-	endpoint := c.getImagingEndpoint()
-	if endpoint == "" {
-		return nil, ErrServiceNotSupported
+	endpoint, err := c.getImagingEndpoint()
+	if err != nil {
+		return nil, err
 	}
 
 	type GetStatus struct {

--- a/not_initialized_test.go
+++ b/not_initialized_test.go
@@ -1,0 +1,317 @@
+package onvif
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// This file covers the error contract described in #64: an empty service
+// endpoint has two entirely different causes, and callers need to tell them
+// apart because the recovery differs. ErrNotInitialized means "call Initialize
+// and retry"; ErrServiceNotSupported means "this device will never do this,
+// stop offering it". Before #64 both cases returned ErrServiceNotSupported, so
+// a missed setup step was indistinguishable from a device limitation.
+
+// serviceOp is one PTZ or Imaging operation, reduced to just its error result.
+// Argument values are irrelevant: every one of these must fail on the endpoint
+// check before it builds a request or touches the network.
+type serviceOp struct {
+	name string
+	call func(context.Context, *Client) error
+}
+
+// ptzOps is every exported PTZ operation. All 13 must agree on the contract -
+// a single one still returning the old error would leave callers unable to
+// trust errors.Is on any of them.
+func ptzOps() []serviceOp {
+	return []serviceOp{
+		{"ContinuousMove", func(ctx context.Context, c *Client) error {
+			return c.ContinuousMove(ctx, testProfileToken, nil, nil)
+		}},
+		{"AbsoluteMove", func(ctx context.Context, c *Client) error {
+			return c.AbsoluteMove(ctx, testProfileToken, nil, nil)
+		}},
+		{"RelativeMove", func(ctx context.Context, c *Client) error {
+			return c.RelativeMove(ctx, testProfileToken, nil, nil)
+		}},
+		{"Stop", func(ctx context.Context, c *Client) error {
+			return c.Stop(ctx, testProfileToken, true, true)
+		}},
+		{"GetStatus", func(ctx context.Context, c *Client) error {
+			_, err := c.GetStatus(ctx, testProfileToken)
+
+			return err
+		}},
+		{"GetPresets", func(ctx context.Context, c *Client) error {
+			_, err := c.GetPresets(ctx, testProfileToken)
+
+			return err
+		}},
+		{"GotoPreset", func(ctx context.Context, c *Client) error {
+			return c.GotoPreset(ctx, testProfileToken, "preset1", nil)
+		}},
+		{"SetPreset", func(ctx context.Context, c *Client) error {
+			_, err := c.SetPreset(ctx, testProfileToken, "name", "preset1")
+
+			return err
+		}},
+		{"RemovePreset", func(ctx context.Context, c *Client) error {
+			return c.RemovePreset(ctx, testProfileToken, "preset1")
+		}},
+		{"GotoHomePosition", func(ctx context.Context, c *Client) error {
+			return c.GotoHomePosition(ctx, testProfileToken, nil)
+		}},
+		{"SetHomePosition", func(ctx context.Context, c *Client) error {
+			return c.SetHomePosition(ctx, testProfileToken)
+		}},
+		{"GetConfiguration", func(ctx context.Context, c *Client) error {
+			_, err := c.GetConfiguration(ctx, "ptzconfig1")
+
+			return err
+		}},
+		{"GetConfigurations", func(ctx context.Context, c *Client) error {
+			_, err := c.GetConfigurations(ctx)
+
+			return err
+		}},
+	}
+}
+
+// imagingOps is every exported Imaging operation.
+//
+// GetImagingSettings, SetImagingSettings and Move are the three that used to
+// silently fall back to the device endpoint while the other four returned an
+// error, so the same client state produced a working call or a "not supported"
+// error depending only on which method the caller reached for. They are
+// included here precisely because that split is what #64 removed.
+func imagingOps() []serviceOp {
+	return []serviceOp{
+		{"GetImagingSettings", func(ctx context.Context, c *Client) error {
+			_, err := c.GetImagingSettings(ctx, testVideoSourceToken)
+
+			return err
+		}},
+		{"SetImagingSettings", func(ctx context.Context, c *Client) error {
+			return c.SetImagingSettings(ctx, testVideoSourceToken, &ImagingSettings{}, true)
+		}},
+		{"Move", func(ctx context.Context, c *Client) error {
+			return c.Move(ctx, testVideoSourceToken, &FocusMove{})
+		}},
+		{"GetOptions", func(ctx context.Context, c *Client) error {
+			_, err := c.GetOptions(ctx, testVideoSourceToken)
+
+			return err
+		}},
+		{"GetMoveOptions", func(ctx context.Context, c *Client) error {
+			_, err := c.GetMoveOptions(ctx, testVideoSourceToken)
+
+			return err
+		}},
+		{"StopFocus", func(ctx context.Context, c *Client) error {
+			return c.StopFocus(ctx, testVideoSourceToken)
+		}},
+		{"GetImagingStatus", func(ctx context.Context, c *Client) error {
+			_, err := c.GetImagingStatus(ctx, testVideoSourceToken)
+
+			return err
+		}},
+	}
+}
+
+// capabilitiesResponse builds a GetCapabilities response advertising only the
+// services named in extra, so a test can produce a client that has genuinely
+// discovered capabilities yet still has no endpoint for a given service.
+func capabilitiesResponse(deviceURL, extra string) string {
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+    <soap:Body>
+        <tds:GetCapabilitiesResponse xmlns:tds="http://www.onvif.org/ver10/device/wsdl">
+            <tds:Capabilities>
+                <tt:Device xmlns:tt="http://www.onvif.org/ver10/schema">
+                    <tt:XAddr>` + deviceURL + `/onvif/device_service</tt:XAddr>
+                </tt:Device>` + extra + `
+            </tds:Capabilities>
+        </tds:GetCapabilitiesResponse>
+    </soap:Body>
+</soap:Envelope>`
+}
+
+// TestPTZOperationsBeforeInitialize asserts every PTZ operation reports
+// ErrNotInitialized - not ErrServiceNotSupported - on a client that has never
+// run Initialize. The device in this test does support PTZ; only the client is
+// unaware, which is exactly the state the old error misdescribed.
+func TestPTZOperationsBeforeInitialize(t *testing.T) {
+	client, err := NewClient("http://192.0.2.1/onvif/device_service")
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+
+	ctx := context.Background()
+	for _, op := range ptzOps() {
+		t.Run(op.name, func(t *testing.T) {
+			err := op.call(ctx, client)
+			if !errors.Is(err, ErrNotInitialized) {
+				t.Errorf("%s() before Initialize = %v, want ErrNotInitialized", op.name, err)
+			}
+			// The two must stay distinguishable; a sentinel that satisfied
+			// both errors.Is checks would defeat the whole point.
+			if errors.Is(err, ErrServiceNotSupported) {
+				t.Errorf("%s() must not also report ErrServiceNotSupported", op.name)
+			}
+		})
+	}
+}
+
+// TestImagingOperationsBeforeInitialize is TestPTZOperationsBeforeInitialize
+// for Imaging, including the three operations that previously reached the
+// device endpoint instead of failing.
+func TestImagingOperationsBeforeInitialize(t *testing.T) {
+	client, err := NewClient("http://192.0.2.1/onvif/device_service")
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+
+	ctx := context.Background()
+	for _, op := range imagingOps() {
+		t.Run(op.name, func(t *testing.T) {
+			err := op.call(ctx, client)
+			if !errors.Is(err, ErrNotInitialized) {
+				t.Errorf("%s() before Initialize = %v, want ErrNotInitialized", op.name, err)
+			}
+			if errors.Is(err, ErrServiceNotSupported) {
+				t.Errorf("%s() must not also report ErrServiceNotSupported", op.name)
+			}
+		})
+	}
+}
+
+// TestPTZOperationsAfterInitializeWithoutPTZ asserts that once capabilities
+// have been fetched, a service the device did not advertise yields
+// ErrServiceNotSupported. This is the case ErrServiceNotSupported is actually
+// for, and it must survive the #64 change - a caller may reasonably use it to
+// decide not to offer PTZ controls at all.
+func TestPTZOperationsAfterInitializeWithoutPTZ(t *testing.T) {
+	mock := NewMockONVIFServer()
+	defer mock.Close()
+
+	// Media only: the device reports no PTZ service.
+	mock.SetResponse("GetCapabilities", capabilitiesResponse(mock.URL(),
+		`<tt:Media xmlns:tt="http://www.onvif.org/ver10/schema">
+                    <tt:XAddr>`+mock.URL()+`/onvif/media_service</tt:XAddr>
+                </tt:Media>`))
+
+	client, err := NewClient(mock.URL(), WithCredentials(testUsername, testPassword))
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := client.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() failed: %v", err)
+	}
+
+	for _, op := range ptzOps() {
+		t.Run(op.name, func(t *testing.T) {
+			err := op.call(ctx, client)
+			if !errors.Is(err, ErrServiceNotSupported) {
+				t.Errorf("%s() after Initialize without PTZ = %v, want ErrServiceNotSupported", op.name, err)
+			}
+			if errors.Is(err, ErrNotInitialized) {
+				t.Errorf("%s() must not report ErrNotInitialized after a successful Initialize", op.name)
+			}
+		})
+	}
+}
+
+// TestImagingOperationsAfterInitializeWithoutImaging is the Imaging
+// counterpart. The default mock's capabilities advertise Device, Media and PTZ
+// but no Imaging, so no override is needed here.
+func TestImagingOperationsAfterInitializeWithoutImaging(t *testing.T) {
+	mock := NewMockONVIFServer()
+	defer mock.Close()
+
+	client, err := NewClient(mock.URL(), WithCredentials(testUsername, testPassword))
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := client.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize() failed: %v", err)
+	}
+
+	for _, op := range imagingOps() {
+		t.Run(op.name, func(t *testing.T) {
+			err := op.call(ctx, client)
+			if !errors.Is(err, ErrServiceNotSupported) {
+				t.Errorf("%s() after Initialize without Imaging = %v, want ErrServiceNotSupported", op.name, err)
+			}
+			if errors.Is(err, ErrNotInitialized) {
+				t.Errorf("%s() must not report ErrNotInitialized after a successful Initialize", op.name)
+			}
+		})
+	}
+}
+
+// TestFailedInitializeLeavesClientUninitialized covers the boundary between
+// the two errors: Initialize returning an error means capabilities were never
+// fetched, so PTZ must still report the recoverable ErrNotInitialized rather
+// than claiming the device lacks the service.
+func TestFailedInitializeLeavesClientUninitialized(t *testing.T) {
+	mock := NewMockONVIFServer()
+	defer mock.Close()
+
+	// A SOAP Fault for GetCapabilities: reachable device, failed discovery.
+	mock.SetResponse("GetCapabilities", mock.responses["default"])
+
+	client, err := NewClient(mock.URL(), WithCredentials(testUsername, testPassword))
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := client.Initialize(ctx); err == nil {
+		t.Fatal("Initialize() succeeded against a faulting GetCapabilities, want error")
+	}
+
+	if err := client.SetHomePosition(ctx, testProfileToken); !errors.Is(err, ErrNotInitialized) {
+		t.Errorf("SetHomePosition() after a failed Initialize = %v, want ErrNotInitialized", err)
+	}
+}
+
+// TestMediaAndEventsStillFallBackToDeviceEndpoint pins the asymmetry that #64
+// deliberately left in place and documented on Initialize, rather than
+// silently relying on it: Media and Events degrade to the device endpoint, so
+// they keep working without Initialize on the many cameras that serve those
+// operations there. Only PTZ and Imaging hard-require Initialize.
+//
+// Without this test, "make everything consistent" is an easy future change to
+// make by accident.
+func TestMediaAndEventsStillFallBackToDeviceEndpoint(t *testing.T) {
+	mock := NewMockONVIFServer()
+	defer mock.Close()
+
+	client, err := NewClient(mock.URL(), WithCredentials(testUsername, testPassword))
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+
+	// Compared against Endpoint() rather than mock.URL(): NewClient
+	// normalizes a bare URL by appending /onvif/device_service.
+	deviceEndpoint := client.Endpoint()
+
+	// No Initialize call: mediaEndpoint and eventEndpoint are both empty.
+	if got := client.getMediaEndpoint(); got != deviceEndpoint {
+		t.Errorf("getMediaEndpoint() without Initialize = %q, want the device endpoint %q", got, deviceEndpoint)
+	}
+	if got := client.getEventEndpoint(); got != deviceEndpoint {
+		t.Errorf("getEventEndpoint() without Initialize = %q, want the device endpoint %q", got, deviceEndpoint)
+	}
+
+	// And the fallback is load-bearing, not just cosmetic: GetProfiles
+	// actually completes against the device endpoint.
+	if _, err := client.GetProfiles(context.Background()); err != nil {
+		t.Errorf("GetProfiles() without Initialize failed: %v", err)
+	}
+}

--- a/ptz.go
+++ b/ptz.go
@@ -11,12 +11,30 @@ import (
 // PTZ service namespace.
 const ptzNamespace = "http://www.onvif.org/ver20/ptz/wsdl"
 
-// getPTZEndpoint returns the PTZ endpoint.
-func (c *Client) getPTZEndpoint() string {
+// getPTZEndpoint returns the discovered PTZ service endpoint.
+//
+// When no endpoint is known it reports which of the two possible reasons
+// applies, rather than conflating them: ErrNotInitialized if Initialize has
+// never succeeded - the device may well support PTZ, the client simply has
+// not looked yet, and the caller's recovery is to call Initialize and retry -
+// or ErrServiceNotSupported if capabilities were fetched and PTZ was absent
+// from them, which is a permanent property of the device and means the caller
+// should stop offering PTZ at all.
+//
+// Both checks are made under one lock so the pair is always consistent.
+func (c *Client) getPTZEndpoint() (string, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return c.ptzEndpoint
+	if c.ptzEndpoint == "" {
+		if !c.initialized {
+			return "", ErrNotInitialized
+		}
+
+		return "", ErrServiceNotSupported
+	}
+
+	return c.ptzEndpoint, nil
 }
 
 // ptzPanTiltXML is a shared type for PTZ pan/tilt XML serialization.
@@ -78,9 +96,9 @@ func convertToPTZSpeedXML(s *PTZSpeed) *ptzSpeedXML {
 
 // ContinuousMove starts continuous PTZ movement.
 func (c *Client) ContinuousMove(ctx context.Context, profileToken string, velocity *PTZSpeed, timeout *string) error {
-	endpoint := c.getPTZEndpoint()
-	if endpoint == "" {
-		return ErrServiceNotSupported
+	endpoint, err := c.getPTZEndpoint()
+	if err != nil {
+		return err
 	}
 
 	type ContinuousMove struct {
@@ -110,9 +128,9 @@ func (c *Client) ContinuousMove(ctx context.Context, profileToken string, veloci
 
 // AbsoluteMove moves PTZ to an absolute position.
 func (c *Client) AbsoluteMove(ctx context.Context, profileToken string, position *PTZVector, speed *PTZSpeed) error {
-	endpoint := c.getPTZEndpoint()
-	if endpoint == "" {
-		return ErrServiceNotSupported
+	endpoint, err := c.getPTZEndpoint()
+	if err != nil {
+		return err
 	}
 
 	type AbsoluteMove struct {
@@ -142,9 +160,9 @@ func (c *Client) AbsoluteMove(ctx context.Context, profileToken string, position
 
 // RelativeMove moves PTZ relative to current position.
 func (c *Client) RelativeMove(ctx context.Context, profileToken string, translation *PTZVector, speed *PTZSpeed) error {
-	endpoint := c.getPTZEndpoint()
-	if endpoint == "" {
-		return ErrServiceNotSupported
+	endpoint, err := c.getPTZEndpoint()
+	if err != nil {
+		return err
 	}
 
 	type RelativeMove struct {
@@ -174,9 +192,9 @@ func (c *Client) RelativeMove(ctx context.Context, profileToken string, translat
 
 // Stop stops PTZ movement.
 func (c *Client) Stop(ctx context.Context, profileToken string, panTilt, zoom bool) error {
-	endpoint := c.getPTZEndpoint()
-	if endpoint == "" {
-		return ErrServiceNotSupported
+	endpoint, err := c.getPTZEndpoint()
+	if err != nil {
+		return err
 	}
 
 	type Stop struct {
@@ -211,9 +229,9 @@ func (c *Client) Stop(ctx context.Context, profileToken string, panTilt, zoom bo
 
 // GetStatus retrieves PTZ status.
 func (c *Client) GetStatus(ctx context.Context, profileToken string) (*PTZStatus, error) {
-	endpoint := c.getPTZEndpoint()
-	if endpoint == "" {
-		return nil, ErrServiceNotSupported
+	endpoint, err := c.getPTZEndpoint()
+	if err != nil {
+		return nil, err
 	}
 
 	type GetStatus struct {
@@ -292,9 +310,9 @@ func (c *Client) GetStatus(ctx context.Context, profileToken string) (*PTZStatus
 
 // GetPresets retrieves PTZ presets.
 func (c *Client) GetPresets(ctx context.Context, profileToken string) ([]*PTZPreset, error) {
-	endpoint := c.getPTZEndpoint()
-	if endpoint == "" {
-		return nil, ErrServiceNotSupported
+	endpoint, err := c.getPTZEndpoint()
+	if err != nil {
+		return nil, err
 	}
 
 	type GetPresets struct {
@@ -368,9 +386,9 @@ func (c *Client) GetPresets(ctx context.Context, profileToken string) ([]*PTZPre
 
 // GotoPreset moves PTZ to a preset position.
 func (c *Client) GotoPreset(ctx context.Context, profileToken, presetToken string, speed *PTZSpeed) error {
-	endpoint := c.getPTZEndpoint()
-	if endpoint == "" {
-		return ErrServiceNotSupported
+	endpoint, err := c.getPTZEndpoint()
+	if err != nil {
+		return err
 	}
 
 	type GotoPreset struct {
@@ -400,9 +418,9 @@ func (c *Client) GotoPreset(ctx context.Context, profileToken, presetToken strin
 
 // SetPreset sets a preset position.
 func (c *Client) SetPreset(ctx context.Context, profileToken, presetName, presetToken string) (string, error) {
-	endpoint := c.getPTZEndpoint()
-	if endpoint == "" {
-		return "", ErrServiceNotSupported
+	endpoint, err := c.getPTZEndpoint()
+	if err != nil {
+		return "", err
 	}
 
 	type SetPreset struct {
@@ -444,9 +462,9 @@ func (c *Client) SetPreset(ctx context.Context, profileToken, presetName, preset
 
 // RemovePreset removes a preset.
 func (c *Client) RemovePreset(ctx context.Context, profileToken, presetToken string) error {
-	endpoint := c.getPTZEndpoint()
-	if endpoint == "" {
-		return ErrServiceNotSupported
+	endpoint, err := c.getPTZEndpoint()
+	if err != nil {
+		return err
 	}
 
 	type RemovePreset struct {
@@ -474,9 +492,9 @@ func (c *Client) RemovePreset(ctx context.Context, profileToken, presetToken str
 
 // GotoHomePosition moves PTZ to home position.
 func (c *Client) GotoHomePosition(ctx context.Context, profileToken string, speed *PTZSpeed) error {
-	endpoint := c.getPTZEndpoint()
-	if endpoint == "" {
-		return ErrServiceNotSupported
+	endpoint, err := c.getPTZEndpoint()
+	if err != nil {
+		return err
 	}
 
 	type GotoHomePosition struct {
@@ -504,9 +522,9 @@ func (c *Client) GotoHomePosition(ctx context.Context, profileToken string, spee
 
 // SetHomePosition sets the current position as home position.
 func (c *Client) SetHomePosition(ctx context.Context, profileToken string) error {
-	endpoint := c.getPTZEndpoint()
-	if endpoint == "" {
-		return ErrServiceNotSupported
+	endpoint, err := c.getPTZEndpoint()
+	if err != nil {
+		return err
 	}
 
 	type SetHomePosition struct {
@@ -532,9 +550,9 @@ func (c *Client) SetHomePosition(ctx context.Context, profileToken string) error
 
 // GetConfiguration retrieves PTZ configuration.
 func (c *Client) GetConfiguration(ctx context.Context, configurationToken string) (*PTZConfiguration, error) {
-	endpoint := c.getPTZEndpoint()
-	if endpoint == "" {
-		return nil, ErrServiceNotSupported
+	endpoint, err := c.getPTZEndpoint()
+	if err != nil {
+		return nil, err
 	}
 
 	type GetConfiguration struct {
@@ -577,9 +595,9 @@ func (c *Client) GetConfiguration(ctx context.Context, configurationToken string
 
 // GetConfigurations retrieves all PTZ configurations.
 func (c *Client) GetConfigurations(ctx context.Context) ([]*PTZConfiguration, error) {
-	endpoint := c.getPTZEndpoint()
-	if endpoint == "" {
-		return nil, ErrServiceNotSupported
+	endpoint, err := c.getPTZEndpoint()
+	if err != nil {
+		return nil, err
 	}
 
 	type GetConfigurations struct {


### PR DESCRIPTION
Fixes #64.

## Problem

PTZ and Imaging returned `ErrServiceNotSupported` whenever the service endpoint was empty. That conflates two states whose recoveries are opposites:

| State | Correct signal | Caller's recovery |
|---|---|---|
| Device genuinely lacks the service | `ErrServiceNotSupported` | Permanent — hide the feature |
| `Initialize` hasn't run | `ErrNotInitialized` | Recoverable — call `Initialize`, retry |

`ErrNotInitialized` already existed in `errors.go` for exactly this, but nothing returned it — `grep` found only the declaration.

## Additional finding: Imaging was inconsistent with itself

The issue states the endpoint check "appears at all 13 PTZ call sites and all 7 Imaging call sites". PTZ checks out. **Imaging was split:**

- `GetImagingSettings`, `SetImagingSettings`, `Move` → fell back to the device endpoint (like Media)
- `GetOptions`, `GetMoveOptions`, `StopFocus`, `GetImagingStatus` → returned `ErrServiceNotSupported`

So identical client state produced either a working call or a "not supported" error depending only on which Imaging method the caller happened to reach for. That's the same defect the issue describes *across* services, also present *within* one — and it changes the fix, since three sites needed converting rather than zero.

Per maintainer decision, all seven now require `Initialize` (consistent with PTZ).

## Approach

`Client` gains an `initialized bool`, set inside `Initialize`'s existing critical section alongside the endpoints it describes. The accessors now resolve the endpoint *and* the reason for its absence in one lock acquisition:

```go
func (c *Client) getPTZEndpoint() (string, error) {
	c.mu.RLock()
	defer c.mu.RUnlock()

	if c.ptzEndpoint == "" {
		if !c.initialized {
			return "", ErrNotInitialized
		}

		return "", ErrServiceNotSupported
	}

	return c.ptzEndpoint, nil
}
```

Resolving both under one lock matters: a two-step "read endpoint, then ask why it was empty" would let a concurrent `Initialize` land between the calls and report `ErrServiceNotSupported` for a service that had just become available.

These are now the single origin of both sentinels for their service — all 13 PTZ and 7 Imaging call sites route through them, and neither error is constructed anywhere else in `ptz.go`/`imaging.go`.

## Behavior change

`GetImagingSettings`, `SetImagingSettings` and `Move` previously worked without `Initialize` on cameras serving Imaging on the device endpoint. They now return `ErrNotInitialized`.

Checked every in-repo caller: `cmd/onvif-cli`, `cmd/onvif-quick`, `cmd/onvif-diagnostics`, `cmd/generate-tests` and all examples call `Initialize` first, so nothing in-repo breaks. The one affected path is `onvif-diagnostics`, which deliberately continues past a failed `Initialize` — it now surfaces `ErrNotInitialized` for Imaging instead of silently guessing the device endpoint, having already logged the discovery failure as an error. That reads as more truthful for a diagnostic tool, but it is a change.

Unexported accessors only; no public API change.

## Asymmetry kept, and now pinned

Media and Events keep their device-endpoint fallback — many cameras do serve those operations there, so `GetProfiles` working without `Initialize` is genuinely useful. `Initialize`'s doc comment now states the split explicitly, and `TestMediaAndEventsStillFallBackToDeviceEndpoint` asserts it (including that `GetProfiles` really completes), so a future "make it all consistent" pass can't quietly remove it.

## Tests

- All 13 PTZ and all 7 Imaging operations, before `Initialize` → `ErrNotInitialized`
- Same 20, after a successful `Initialize` against capabilities lacking the service → `ErrServiceNotSupported`
- Both assert the sentinels stay mutually exclusive, so `errors.Is` remains a reliable discriminator
- Failed `Initialize` → still `ErrNotInitialized` (capabilities were never fetched)
- Media/Events fallback preserved

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean
- `go test -count=1 -race ./...` — all packages pass (`-count=1` to defeat the test cache)
- `golangci-lint run --timeout=5m --max-issues-per-linter=0 --max-same-issues=0 ./...` — 0 issues
- Coverage side effect: `ptz.go` 85.7% → 92.7%, `imaging.go` 77.2% → 83.5%, package 84.9% → 85.7%. These tests cover the previously-untested empty-endpoint branches, which is partial progress on #11 and #12.