### PR TITLE
fix: map the config fields that were silently dropped (#86, #87)

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -1,0 +1,151 @@
+package onvif
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ErrInvalidXSDuration is returned by parseXSDuration for input that is not a
+// duration it can represent as a time.Duration.
+var ErrInvalidXSDuration = errors.New("invalid xs:duration")
+
+// xsDurationPattern matches the xs:duration lexical form used by ONVIF for
+// timeout-valued elements: an optional sign, then P, then an optional date
+// part, then an optional T-prefixed time part.
+//
+// Deliberately more permissive than server/event.go's isoDurationPattern,
+// which covers only the "PT<n>M<n>S" subset this library's own formatDuration
+// emits. That narrowness is correct there - the server parses values produced
+// by an ONVIF client, and #62 scoped it to what could actually be tested
+// against. Here the producer is a real camera's firmware, which is free to use
+// any lexical form the schema allows, so "PT60S", "PT1M", "PT0H1M0S" and "P1D"
+// all have to be understood.
+var xsDurationPattern = regexp.MustCompile(
+	`^(-)?P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$`,
+)
+
+// Submatch indices into xsDurationPattern.
+const (
+	xsDurSign = 1
+	xsDurYear = 2
+	xsDurMon  = 3
+	xsDurDay  = 4
+	xsDurHour = 5
+	xsDurMin  = 6
+	xsDurSec  = 7
+)
+
+const hoursPerDay = 24
+
+// parseXSDuration parses an xs:duration into a time.Duration.
+//
+// Years and months are rejected rather than approximated: neither has a fixed
+// length, so "P1M" cannot be converted without inventing a calendar context
+// the caller never supplied. Every ONVIF element this is used for is a
+// timeout, where years and months do not occur in practice, so rejecting is
+// preferable to silently returning a number that is wrong by up to three days.
+func parseXSDuration(s string) (time.Duration, error) {
+	m := xsDurationPattern.FindStringSubmatch(s)
+	if m == nil {
+		return 0, fmt.Errorf("%w: %q", ErrInvalidXSDuration, s)
+	}
+
+	// "P" and "PT" match the pattern but carry no components, and xs:duration
+	// requires at least one. Likewise a "T" with nothing after it.
+	if !hasAnyComponent(m) {
+		return 0, fmt.Errorf("%w: %q has no components", ErrInvalidXSDuration, s)
+	}
+	if strings.Contains(s, "T") && m[xsDurHour] == "" && m[xsDurMin] == "" && m[xsDurSec] == "" {
+		return 0, fmt.Errorf("%w: %q has an empty time part", ErrInvalidXSDuration, s)
+	}
+
+	if m[xsDurYear] != "" || m[xsDurMon] != "" {
+		return 0, fmt.Errorf(
+			"%w: %q uses years or months, which have no fixed length", ErrInvalidXSDuration, s,
+		)
+	}
+
+	total, ok := sumDurationParts(m)
+	if !ok {
+		return 0, fmt.Errorf("%w: %q is out of range", ErrInvalidXSDuration, s)
+	}
+
+	if m[xsDurSign] == "-" {
+		total = -total
+	}
+
+	return total, nil
+}
+
+// hasAnyComponent reports whether the match carries at least one numeric
+// component.
+func hasAnyComponent(m []string) bool {
+	for _, i := range []int{xsDurYear, xsDurMon, xsDurDay, xsDurHour, xsDurMin, xsDurSec} {
+		if m[i] != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// sumDurationParts adds up the day, hour, minute and second components,
+// reporting false if any of them will not fit.
+//
+// The regex has already established that every component is a run of digits,
+// so the only way a conversion fails here is overflow. That makes a bool the
+// honest return: there is no underlying error worth propagating, and the
+// caller builds its own ErrInvalidXSDuration message either way.
+func sumDurationParts(m []string) (total time.Duration, ok bool) {
+	for _, part := range []struct {
+		text string
+		unit time.Duration
+	}{
+		{m[xsDurDay], hoursPerDay * time.Hour},
+		{m[xsDurHour], time.Hour},
+		{m[xsDurMin], time.Minute},
+	} {
+		if part.text == "" {
+			continue
+		}
+		n, err := strconv.Atoi(part.text)
+		if err != nil {
+			return 0, false
+		}
+		total += time.Duration(n) * part.unit
+	}
+
+	// Seconds may carry a fractional part, so they go through ParseFloat.
+	if m[xsDurSec] != "" {
+		secs, err := strconv.ParseFloat(m[xsDurSec], 64)
+		if err != nil {
+			return 0, false
+		}
+		total += time.Duration(secs * float64(time.Second))
+	}
+
+	return total, true
+}
+
+// parseXSDurationOrZero parses an xs:duration, returning zero for input that
+// cannot be parsed.
+//
+// Response mapping uses this rather than parseXSDuration directly. A camera
+// reporting a malformed timeout should not fail the whole call - the caller
+// asked for a configuration, and every other field in it is still good - and
+// Client has no logger to report the discrepancy through. The zero value is
+// indistinguishable from an absent element, which is the one wart here; the
+// alternative of failing the call would make an unrelated field's formatting
+// quirk break an entire operation against otherwise-working firmware.
+func parseXSDurationOrZero(s string) time.Duration {
+	d, err := parseXSDuration(s)
+	if err != nil {
+		return 0
+	}
+
+	return d
+}

--- a/duration_test.go
+++ b/duration_test.go
@@ -1,0 +1,135 @@
+package onvif
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestParseXSDuration(t *testing.T) {
+	tests := []struct {
+		input string
+		want  time.Duration
+	}{
+		// The forms this library's own formatDuration emits.
+		{input: "PT60S", want: 60 * time.Second},
+		{input: "PT1M", want: time.Minute},
+		{input: "PT1M30S", want: 90 * time.Second},
+
+		// Forms a camera is free to send that formatDuration never produces,
+		// and that server/event.go's deliberately narrow parser rejects.
+		{input: "PT0H1M0S", want: time.Minute},
+		{input: "PT2H", want: 2 * time.Hour},
+		{input: "P1D", want: 24 * time.Hour},
+		{input: "P1DT2H3M4S", want: 24*time.Hour + 2*time.Hour + 3*time.Minute + 4*time.Second},
+		{input: "PT0S", want: 0},
+
+		// Fractional seconds are permitted by xs:duration.
+		{input: "PT1.5S", want: 1500 * time.Millisecond},
+
+		// A negative duration is legal in xs:duration.
+		{input: "-PT30S", want: -30 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseXSDuration(tt.input)
+			if err != nil {
+				t.Fatalf("parseXSDuration(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseXSDuration(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseXSDurationRejects(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "empty", input: ""},
+		{name: "no components", input: "P"},
+		{name: "empty time part", input: "PT"},
+		{name: "not a duration", input: "garbage"},
+		{name: "missing P", input: "T30S"},
+		{name: "trailing junk", input: "PT30Sx"},
+		{name: "unit out of order", input: "PT30S1M"},
+
+		// Years and months have no fixed length, so they are refused rather
+		// than approximated against an invented calendar.
+		{name: "years", input: "P1Y"},
+		{name: "months", input: "P1M"},
+		{name: "years and months", input: "P1Y6M"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseXSDuration(tt.input)
+			if !errors.Is(err, ErrInvalidXSDuration) {
+				t.Errorf("parseXSDuration(%q) error = %v, want ErrInvalidXSDuration", tt.input, err)
+			}
+			if got != 0 {
+				t.Errorf("parseXSDuration(%q) = %v, want 0 alongside the error", tt.input, got)
+			}
+		})
+	}
+}
+
+// TestParseXSDurationMinuteVersusMonth pins the one ambiguity in the grammar
+// that a hand-written parser is most likely to get wrong: "M" means months
+// before the T separator and minutes after it.
+func TestParseXSDurationMinuteVersusMonth(t *testing.T) {
+	if _, err := parseXSDuration("P5M"); !errors.Is(err, ErrInvalidXSDuration) {
+		t.Errorf("P5M should be five months and therefore refused, got err = %v", err)
+	}
+
+	got, err := parseXSDuration("PT5M")
+	if err != nil {
+		t.Fatalf("PT5M should be five minutes, got err = %v", err)
+	}
+	if got != 5*time.Minute {
+		t.Errorf("parseXSDuration(\"PT5M\") = %v, want 5m", got)
+	}
+}
+
+// TestParseXSDurationOrZero covers the response-mapping wrapper: a camera
+// sending a malformed timeout must not fail the whole call.
+func TestParseXSDurationOrZero(t *testing.T) {
+	if got := parseXSDurationOrZero("PT45S"); got != 45*time.Second {
+		t.Errorf("parseXSDurationOrZero(\"PT45S\") = %v, want 45s", got)
+	}
+	if got := parseXSDurationOrZero("nonsense"); got != 0 {
+		t.Errorf("parseXSDurationOrZero(\"nonsense\") = %v, want 0", got)
+	}
+	if got := parseXSDurationOrZero(""); got != 0 {
+		t.Errorf("parseXSDurationOrZero(\"\") = %v, want 0", got)
+	}
+}
+
+// TestParseXSDurationRoundTripsFormatDuration checks the two halves agree, so
+// a value written by SetAudioEncoderConfiguration can be read back by
+// GetAudioEncoderConfiguration.
+func TestParseXSDurationRoundTripsFormatDuration(t *testing.T) {
+	for _, want := range []time.Duration{
+		1 * time.Second,
+		30 * time.Second,
+		59 * time.Second,
+		time.Minute,
+		90 * time.Second,
+		10 * time.Minute,
+		time.Hour,
+	} {
+		formatted := formatDuration(want)
+		got, err := parseXSDuration(formatted)
+		if err != nil {
+			t.Errorf("parseXSDuration(formatDuration(%v)) = %q: %v", want, formatted, err)
+
+			continue
+		}
+		if got != want {
+			t.Errorf("round trip of %v through %q gave %v", want, formatted, got)
+		}
+	}
+}

--- a/media.go
+++ b/media.go
@@ -275,6 +275,7 @@ func (c *Client) GetVideoEncoderConfiguration(
 				EncodingInterval int `xml:"EncodingInterval"`
 				BitrateLimit     int `xml:"BitrateLimit"`
 			} `xml:"RateControl"`
+			SessionTimeout string `xml:"SessionTimeout"`
 		} `xml:"Configuration"`
 	}
 
@@ -293,11 +294,12 @@ func (c *Client) GetVideoEncoderConfiguration(
 	}
 
 	config := &VideoEncoderConfiguration{
-		Token:    resp.Configuration.Token,
-		Name:     resp.Configuration.Name,
-		UseCount: resp.Configuration.UseCount,
-		Encoding: resp.Configuration.Encoding,
-		Quality:  resp.Configuration.Quality,
+		Token:          resp.Configuration.Token,
+		Name:           resp.Configuration.Name,
+		UseCount:       resp.Configuration.UseCount,
+		Encoding:       resp.Configuration.Encoding,
+		Quality:        resp.Configuration.Quality,
+		SessionTimeout: parseXSDurationOrZero(resp.Configuration.SessionTimeout),
 	}
 
 	if resp.Configuration.Resolution != nil {
@@ -541,6 +543,7 @@ func (c *Client) SetVideoEncoderConfiguration(
 				EncodingInterval int `xml:"tt:EncodingInterval"`
 				BitrateLimit     int `xml:"tt:BitrateLimit"`
 			} `xml:"tt:RateControl,omitempty"`
+			SessionTimeout string `xml:"tt:SessionTimeout,omitempty"`
 		} `xml:"trt:Configuration"`
 		ForcePersistence bool `xml:"trt:ForcePersistence"`
 	}
@@ -568,6 +571,10 @@ func (c *Client) SetVideoEncoderConfiguration(
 
 	if config.Quality > 0 {
 		req.Configuration.Quality = &config.Quality
+	}
+
+	if config.SessionTimeout > 0 {
+		req.Configuration.SessionTimeout = formatDuration(config.SessionTimeout)
 	}
 
 	if config.RateControl != nil {
@@ -847,12 +854,13 @@ func (c *Client) GetAudioEncoderConfiguration(
 	}
 
 	config := &AudioEncoderConfiguration{
-		Token:      resp.Configuration.Token,
-		Name:       resp.Configuration.Name,
-		UseCount:   resp.Configuration.UseCount,
-		Encoding:   resp.Configuration.Encoding,
-		Bitrate:    resp.Configuration.Bitrate,
-		SampleRate: resp.Configuration.SampleRate,
+		Token:          resp.Configuration.Token,
+		Name:           resp.Configuration.Name,
+		UseCount:       resp.Configuration.UseCount,
+		Encoding:       resp.Configuration.Encoding,
+		Bitrate:        resp.Configuration.Bitrate,
+		SampleRate:     resp.Configuration.SampleRate,
+		SessionTimeout: parseXSDurationOrZero(resp.Configuration.SessionTimeout),
 	}
 
 	if resp.Configuration.Multicast != nil {
@@ -922,6 +930,9 @@ func (c *Client) SetAudioEncoderConfiguration(
 	}
 	if config.SampleRate > 0 {
 		req.Configuration.SampleRate = config.SampleRate
+	}
+	if config.SessionTimeout > 0 {
+		req.Configuration.SessionTimeout = formatDuration(config.SessionTimeout)
 	}
 
 	if config.Multicast != nil {
@@ -1016,10 +1027,11 @@ func (c *Client) GetMetadataConfiguration(
 	}
 
 	config := &MetadataConfiguration{
-		Token:     resp.Configuration.Token,
-		Name:      resp.Configuration.Name,
-		UseCount:  resp.Configuration.UseCount,
-		Analytics: resp.Configuration.Analytics,
+		Token:          resp.Configuration.Token,
+		Name:           resp.Configuration.Name,
+		UseCount:       resp.Configuration.UseCount,
+		Analytics:      resp.Configuration.Analytics,
+		SessionTimeout: parseXSDurationOrZero(resp.Configuration.SessionTimeout),
 	}
 
 	if resp.Configuration.PTZStatus != nil {
@@ -1098,6 +1110,9 @@ func (c *Client) SetMetadataConfiguration(
 	req.Configuration.Name = config.Name
 	req.Configuration.UseCount = config.UseCount
 	req.Configuration.Analytics = config.Analytics
+	if config.SessionTimeout > 0 {
+		req.Configuration.SessionTimeout = formatDuration(config.SessionTimeout)
+	}
 
 	if config.PTZStatus != nil {
 		req.Configuration.PTZStatus = &struct {
@@ -2407,11 +2422,12 @@ func (c *Client) GetVideoEncoderConfigurations(ctx context.Context) ([]*VideoEnc
 	configs := make([]*VideoEncoderConfiguration, len(resp.Configurations))
 	for i, cfg := range resp.Configurations {
 		config := &VideoEncoderConfiguration{
-			Token:    cfg.Token,
-			Name:     cfg.Name,
-			UseCount: cfg.UseCount,
-			Encoding: cfg.Encoding,
-			Quality:  cfg.Quality,
+			Token:          cfg.Token,
+			Name:           cfg.Name,
+			UseCount:       cfg.UseCount,
+			Encoding:       cfg.Encoding,
+			Quality:        cfg.Quality,
+			SessionTimeout: parseXSDurationOrZero(cfg.SessionTimeout),
 		}
 
 		if cfg.Resolution != nil {
@@ -2512,12 +2528,13 @@ func (c *Client) GetAudioEncoderConfigurations(ctx context.Context) ([]*AudioEnc
 	configs := make([]*AudioEncoderConfiguration, len(resp.Configurations))
 	for i, cfg := range resp.Configurations {
 		config := &AudioEncoderConfiguration{
-			Token:      cfg.Token,
-			Name:       cfg.Name,
-			UseCount:   cfg.UseCount,
-			Encoding:   cfg.Encoding,
-			Bitrate:    cfg.Bitrate,
-			SampleRate: cfg.SampleRate,
+			Token:          cfg.Token,
+			Name:           cfg.Name,
+			UseCount:       cfg.UseCount,
+			Encoding:       cfg.Encoding,
+			Bitrate:        cfg.Bitrate,
+			SampleRate:     cfg.SampleRate,
+			SessionTimeout: parseXSDurationOrZero(cfg.SessionTimeout),
 		}
 
 		if cfg.Multicast != nil {
@@ -2880,6 +2897,7 @@ func (c *Client) GetCompatibleVideoEncoderConfigurations(
 				EncodingInterval int `xml:"EncodingInterval"`
 				BitrateLimit     int `xml:"BitrateLimit"`
 			} `xml:"RateControl"`
+			SessionTimeout string `xml:"SessionTimeout"`
 		} `xml:"Configurations"`
 	}
 
@@ -2900,11 +2918,12 @@ func (c *Client) GetCompatibleVideoEncoderConfigurations(
 	configs := make([]*VideoEncoderConfiguration, len(resp.Configurations))
 	for i, cfg := range resp.Configurations {
 		config := &VideoEncoderConfiguration{
-			Token:    cfg.Token,
-			Name:     cfg.Name,
-			UseCount: cfg.UseCount,
-			Encoding: cfg.Encoding,
-			Quality:  cfg.Quality,
+			Token:          cfg.Token,
+			Name:           cfg.Name,
+			UseCount:       cfg.UseCount,
+			Encoding:       cfg.Encoding,
+			Quality:        cfg.Quality,
+			SessionTimeout: parseXSDurationOrZero(cfg.SessionTimeout),
 		}
 
 		if cfg.Resolution != nil {
@@ -3009,12 +3028,13 @@ func (c *Client) GetCompatibleAudioEncoderConfigurations(
 	type GetCompatibleAudioEncoderConfigurationsResponse struct {
 		XMLName        xml.Name `xml:"GetCompatibleAudioEncoderConfigurationsResponse"`
 		Configurations []struct {
-			Token      string `xml:"token,attr"`
-			Name       string `xml:"Name"`
-			UseCount   int    `xml:"UseCount"`
-			Encoding   string `xml:"Encoding"`
-			Bitrate    int    `xml:"Bitrate"`
-			SampleRate int    `xml:"SampleRate"`
+			Token          string `xml:"token,attr"`
+			Name           string `xml:"Name"`
+			UseCount       int    `xml:"UseCount"`
+			Encoding       string `xml:"Encoding"`
+			Bitrate        int    `xml:"Bitrate"`
+			SampleRate     int    `xml:"SampleRate"`
+			SessionTimeout string `xml:"SessionTimeout"`
 		} `xml:"Configurations"`
 	}
 
@@ -3035,12 +3055,13 @@ func (c *Client) GetCompatibleAudioEncoderConfigurations(
 	configs := make([]*AudioEncoderConfiguration, len(resp.Configurations))
 	for i, cfg := range resp.Configurations {
 		configs[i] = &AudioEncoderConfiguration{
-			Token:      cfg.Token,
-			Name:       cfg.Name,
-			UseCount:   cfg.UseCount,
-			Encoding:   cfg.Encoding,
-			Bitrate:    cfg.Bitrate,
-			SampleRate: cfg.SampleRate,
+			Token:          cfg.Token,
+			Name:           cfg.Name,
+			UseCount:       cfg.UseCount,
+			Encoding:       cfg.Encoding,
+			Bitrate:        cfg.Bitrate,
+			SampleRate:     cfg.SampleRate,
+			SessionTimeout: parseXSDurationOrZero(cfg.SessionTimeout),
 		}
 	}
 
@@ -3154,10 +3175,11 @@ func (c *Client) GetCompatibleMetadataConfigurations(ctx context.Context, profil
 	type GetCompatibleMetadataConfigurationsResponse struct {
 		XMLName        xml.Name `xml:"GetCompatibleMetadataConfigurationsResponse"`
 		Configurations []struct {
-			Token     string `xml:"token,attr"`
-			Name      string `xml:"Name"`
-			UseCount  int    `xml:"UseCount"`
-			Analytics bool   `xml:"Analytics"`
+			Token          string `xml:"token,attr"`
+			Name           string `xml:"Name"`
+			UseCount       int    `xml:"UseCount"`
+			Analytics      bool   `xml:"Analytics"`
+			SessionTimeout string `xml:"SessionTimeout"`
 		} `xml:"Configurations"`
 	}
 
@@ -3178,10 +3200,11 @@ func (c *Client) GetCompatibleMetadataConfigurations(ctx context.Context, profil
 	configs := make([]*MetadataConfiguration, len(resp.Configurations))
 	for i, cfg := range resp.Configurations {
 		configs[i] = &MetadataConfiguration{
-			Token:     cfg.Token,
-			Name:      cfg.Name,
-			UseCount:  cfg.UseCount,
-			Analytics: cfg.Analytics,
+			Token:          cfg.Token,
+			Name:           cfg.Name,
+			UseCount:       cfg.UseCount,
+			Analytics:      cfg.Analytics,
+			SessionTimeout: parseXSDurationOrZero(cfg.SessionTimeout),
 		}
 	}
 
@@ -3292,10 +3315,11 @@ func (c *Client) GetMetadataConfigurations(ctx context.Context) ([]*MetadataConf
 	type GetMetadataConfigurationsResponse struct {
 		XMLName        xml.Name `xml:"GetMetadataConfigurationsResponse"`
 		Configurations []struct {
-			Token     string `xml:"token,attr"`
-			Name      string `xml:"Name"`
-			UseCount  int    `xml:"UseCount"`
-			Analytics bool   `xml:"Analytics"`
+			Token          string `xml:"token,attr"`
+			Name           string `xml:"Name"`
+			UseCount       int    `xml:"UseCount"`
+			Analytics      bool   `xml:"Analytics"`
+			SessionTimeout string `xml:"SessionTimeout"`
 		} `xml:"Configurations"`
 	}
 
@@ -3315,10 +3339,11 @@ func (c *Client) GetMetadataConfigurations(ctx context.Context) ([]*MetadataConf
 	configs := make([]*MetadataConfiguration, len(resp.Configurations))
 	for i, cfg := range resp.Configurations {
 		configs[i] = &MetadataConfiguration{
-			Token:     cfg.Token,
-			Name:      cfg.Name,
-			UseCount:  cfg.UseCount,
-			Analytics: cfg.Analytics,
+			Token:          cfg.Token,
+			Name:           cfg.Name,
+			UseCount:       cfg.UseCount,
+			Analytics:      cfg.Analytics,
+			SessionTimeout: parseXSDurationOrZero(cfg.SessionTimeout),
 		}
 	}
 

--- a/ptz.go
+++ b/ptz.go
@@ -94,6 +94,118 @@ func convertToPTZSpeedXML(s *PTZSpeed) *ptzSpeedXML {
 	return result
 }
 
+// ptzFloatRangeXML is the wire form of a float range, used for the pan/tilt
+// and zoom limit descriptions.
+type ptzFloatRangeXML struct {
+	Min float64 `xml:"Min"`
+	Max float64 `xml:"Max"`
+}
+
+// ptzConfigurationXML is the wire form of a PTZConfiguration.
+//
+// Shared by GetConfiguration and GetConfigurations, which return the same
+// element and previously each declared their own four-field subset of it.
+//
+// The misspelling in DefaultAbsolutePantTiltPositionSpace ("Pant") is the
+// ONVIF WSDL's own and must be reproduced exactly for the element to match.
+type ptzConfigurationXML struct {
+	Token                                  string       `xml:"token,attr"`
+	Name                                   string       `xml:"Name"`
+	UseCount                               int          `xml:"UseCount"`
+	NodeToken                              string       `xml:"NodeToken"`
+	DefaultAbsolutePantTiltPositionSpace   string       `xml:"DefaultAbsolutePantTiltPositionSpace"`
+	DefaultAbsoluteZoomPositionSpace       string       `xml:"DefaultAbsoluteZoomPositionSpace"`
+	DefaultRelativePanTiltTranslationSpace string       `xml:"DefaultRelativePanTiltTranslationSpace"`
+	DefaultRelativeZoomTranslationSpace    string       `xml:"DefaultRelativeZoomTranslationSpace"`
+	DefaultContinuousPanTiltVelocitySpace  string       `xml:"DefaultContinuousPanTiltVelocitySpace"`
+	DefaultContinuousZoomVelocitySpace     string       `xml:"DefaultContinuousZoomVelocitySpace"`
+	DefaultPTZSpeed                        *ptzSpeedXML `xml:"DefaultPTZSpeed"`
+	DefaultPTZTimeout                      string       `xml:"DefaultPTZTimeout"`
+	PanTiltLimits                          *struct {
+		Range *struct {
+			URI    string            `xml:"URI"`
+			XRange *ptzFloatRangeXML `xml:"XRange"`
+			YRange *ptzFloatRangeXML `xml:"YRange"`
+		} `xml:"Range"`
+	} `xml:"PanTiltLimits"`
+	ZoomLimits *struct {
+		Range *struct {
+			URI    string            `xml:"URI"`
+			XRange *ptzFloatRangeXML `xml:"XRange"`
+		} `xml:"Range"`
+	} `xml:"ZoomLimits"`
+}
+
+// toPTZConfiguration converts the wire form into the library's type.
+//
+// DefaultPTZTimeout is an xs:duration, which is why it needs
+// parseXSDurationOrZero rather than a direct assignment - the reason it, and
+// the rest of these fields, went unmapped until #87.
+func (x *ptzConfigurationXML) toPTZConfiguration() *PTZConfiguration {
+	config := &PTZConfiguration{
+		Token:                                  x.Token,
+		Name:                                   x.Name,
+		UseCount:                               x.UseCount,
+		NodeToken:                              x.NodeToken,
+		DefaultAbsolutePantTiltPositionSpace:   x.DefaultAbsolutePantTiltPositionSpace,
+		DefaultAbsoluteZoomPositionSpace:       x.DefaultAbsoluteZoomPositionSpace,
+		DefaultRelativePanTiltTranslationSpace: x.DefaultRelativePanTiltTranslationSpace,
+		DefaultRelativeZoomTranslationSpace:    x.DefaultRelativeZoomTranslationSpace,
+		DefaultContinuousPanTiltVelocitySpace:  x.DefaultContinuousPanTiltVelocitySpace,
+		DefaultContinuousZoomVelocitySpace:     x.DefaultContinuousZoomVelocitySpace,
+		DefaultPTZTimeout:                      parseXSDurationOrZero(x.DefaultPTZTimeout),
+	}
+
+	if x.DefaultPTZSpeed != nil {
+		config.DefaultPTZSpeed = &PTZSpeed{}
+		if x.DefaultPTZSpeed.PanTilt != nil {
+			config.DefaultPTZSpeed.PanTilt = &Vector2D{
+				X:     x.DefaultPTZSpeed.PanTilt.X,
+				Y:     x.DefaultPTZSpeed.PanTilt.Y,
+				Space: x.DefaultPTZSpeed.PanTilt.Space,
+			}
+		}
+		if x.DefaultPTZSpeed.Zoom != nil {
+			config.DefaultPTZSpeed.Zoom = &Vector1D{
+				X:     x.DefaultPTZSpeed.Zoom.X,
+				Space: x.DefaultPTZSpeed.Zoom.Space,
+			}
+		}
+	}
+
+	if x.PanTiltLimits != nil {
+		config.PanTiltLimits = &PanTiltLimits{}
+		if r := x.PanTiltLimits.Range; r != nil {
+			config.PanTiltLimits.Range = &Space2DDescription{
+				URI:    r.URI,
+				XRange: toFloatRange(r.XRange),
+				YRange: toFloatRange(r.YRange),
+			}
+		}
+	}
+
+	if x.ZoomLimits != nil {
+		config.ZoomLimits = &ZoomLimits{}
+		if r := x.ZoomLimits.Range; r != nil {
+			config.ZoomLimits.Range = &Space1DDescription{
+				URI:    r.URI,
+				XRange: toFloatRange(r.XRange),
+			}
+		}
+	}
+
+	return config
+}
+
+// toFloatRange converts a wire float range, preserving nil.
+func toFloatRange(r *ptzFloatRangeXML) *FloatRange {
+	if r == nil {
+		return nil
+	}
+
+	return &FloatRange{Min: r.Min, Max: r.Max}
+}
+
 // ContinuousMove starts continuous PTZ movement.
 func (c *Client) ContinuousMove(ctx context.Context, profileToken string, velocity *PTZSpeed, timeout *string) error {
 	endpoint, err := c.getPTZEndpoint()
@@ -562,13 +674,8 @@ func (c *Client) GetConfiguration(ctx context.Context, configurationToken string
 	}
 
 	type GetConfigurationResponse struct {
-		XMLName          xml.Name `xml:"GetConfigurationResponse"`
-		PTZConfiguration struct {
-			Token     string `xml:"token,attr"`
-			Name      string `xml:"Name"`
-			UseCount  int    `xml:"UseCount"`
-			NodeToken string `xml:"NodeToken"`
-		} `xml:"PTZConfiguration"`
+		XMLName          xml.Name            `xml:"GetConfigurationResponse"`
+		PTZConfiguration ptzConfigurationXML `xml:"PTZConfiguration"`
 	}
 
 	req := GetConfiguration{
@@ -585,12 +692,7 @@ func (c *Client) GetConfiguration(ctx context.Context, configurationToken string
 		return nil, fmt.Errorf("GetConfiguration failed: %w", err)
 	}
 
-	return &PTZConfiguration{
-		Token:     resp.PTZConfiguration.Token,
-		Name:      resp.PTZConfiguration.Name,
-		UseCount:  resp.PTZConfiguration.UseCount,
-		NodeToken: resp.PTZConfiguration.NodeToken,
-	}, nil
+	return resp.PTZConfiguration.toPTZConfiguration(), nil
 }
 
 // GetConfigurations retrieves all PTZ configurations.
@@ -606,13 +708,8 @@ func (c *Client) GetConfigurations(ctx context.Context) ([]*PTZConfiguration, er
 	}
 
 	type GetConfigurationsResponse struct {
-		XMLName          xml.Name `xml:"GetConfigurationsResponse"`
-		PTZConfiguration []struct {
-			Token     string `xml:"token,attr"`
-			Name      string `xml:"Name"`
-			UseCount  int    `xml:"UseCount"`
-			NodeToken string `xml:"NodeToken"`
-		} `xml:"PTZConfiguration"`
+		XMLName          xml.Name              `xml:"GetConfigurationsResponse"`
+		PTZConfiguration []ptzConfigurationXML `xml:"PTZConfiguration"`
 	}
 
 	req := GetConfigurations{
@@ -629,13 +726,8 @@ func (c *Client) GetConfigurations(ctx context.Context) ([]*PTZConfiguration, er
 	}
 
 	configs := make([]*PTZConfiguration, len(resp.PTZConfiguration))
-	for i, cfg := range resp.PTZConfiguration {
-		configs[i] = &PTZConfiguration{
-			Token:     cfg.Token,
-			Name:      cfg.Name,
-			UseCount:  cfg.UseCount,
-			NodeToken: cfg.NodeToken,
-		}
+	for i := range resp.PTZConfiguration {
+		configs[i] = resp.PTZConfiguration[i].toPTZConfiguration()
 	}
 
 	return configs, nil

--- a/ptz.go
+++ b/ptz.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
+	"time"
 
 	"github.com/0x524a/onvif-go/internal/soap"
 )
@@ -415,6 +416,13 @@ func (c *Client) GetStatus(ctx context.Context, profileToken string) (*PTZStatus
 			PanTilt: resp.PTZStatus.MoveStatus.PanTilt,
 			Zoom:    resp.PTZStatus.MoveStatus.Zoom,
 		}
+	}
+
+	// A timestamp the camera formats unexpectedly leaves UTCTime zero rather
+	// than failing the call, matching how event.go treats the same field: the
+	// position and move status are the point of GetStatus and are still good.
+	if t, err := time.Parse(time.RFC3339, resp.PTZStatus.UTCTime); err == nil {
+		status.UTCTime = t
 	}
 
 	return status, nil

--- a/ptz_configuration_test.go
+++ b/ptz_configuration_test.go
@@ -211,6 +211,43 @@ func TestGetConfigurationOptionalsAbsent(t *testing.T) {
 	}
 }
 
+// TestGetConfigurationPartialLimits covers a camera that reports a limit range
+// but omits one of its axes. The axis must come back nil, so that "no limit
+// reported for this axis" stays distinguishable from "this axis is limited to
+// 0..0" - a range a caller would read as the axis being immovable.
+func TestGetConfigurationPartialLimits(t *testing.T) {
+	body := `<GetConfigurationResponse>
+        <PTZConfiguration token="cfg-partial">
+            <Name>Partial</Name>
+            <UseCount>1</UseCount>
+            <NodeToken>node-1</NodeToken>
+            <PanTiltLimits>
+                <Range>
+                    <URI>space/pantilt-limit</URI>
+                    <XRange><Min>-1</Min><Max>2</Max></XRange>
+                </Range>
+            </PanTiltLimits>
+        </PTZConfiguration>
+    </GetConfigurationResponse>`
+	client := newPTZTestClient(t, newSOAPTestServer(t, body))
+
+	config, err := client.GetConfiguration(context.Background(), "cfg-partial")
+	if err != nil {
+		t.Fatalf("GetConfiguration() error = %v", err)
+	}
+
+	if config.PanTiltLimits == nil || config.PanTiltLimits.Range == nil {
+		t.Fatalf("PanTiltLimits = %+v, want the range from the response", config.PanTiltLimits)
+	}
+	if config.PanTiltLimits.Range.XRange == nil {
+		t.Error("PanTiltLimits.Range.XRange = nil, want the reported range")
+	}
+	if config.PanTiltLimits.Range.YRange != nil {
+		t.Errorf("PanTiltLimits.Range.YRange = %+v, want nil when the camera omits it",
+			config.PanTiltLimits.Range.YRange)
+	}
+}
+
 // TestGetStatusMapsUTCTime covers #89. The zero time was indistinguishable
 // from a camera that reported no timestamp, which is why no existing GetStatus
 // assertion could fail on it.

--- a/ptz_configuration_test.go
+++ b/ptz_configuration_test.go
@@ -1,0 +1,209 @@
+package onvif
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Tests for #87: GetConfiguration and GetConfigurations returned a
+// PTZConfiguration with 10 of its 14 fields permanently zero, because the
+// response structs declared only the other four.
+//
+// Every value below is distinct. That is deliberate: a mapping test whose
+// fields share values cannot catch two of them being swapped, which is the
+// mistake most likely to be made when wiring up a struct this wide.
+
+const ptzConfigurationResponseBody = `
+    <PTZConfiguration token="cfg-42">
+        <Name>Main PTZ</Name>
+        <UseCount>7</UseCount>
+        <NodeToken>node-9</NodeToken>
+        <DefaultAbsolutePantTiltPositionSpace>space/abs-pantilt</DefaultAbsolutePantTiltPositionSpace>
+        <DefaultAbsoluteZoomPositionSpace>space/abs-zoom</DefaultAbsoluteZoomPositionSpace>
+        <DefaultRelativePanTiltTranslationSpace>space/rel-pantilt</DefaultRelativePanTiltTranslationSpace>
+        <DefaultRelativeZoomTranslationSpace>space/rel-zoom</DefaultRelativeZoomTranslationSpace>
+        <DefaultContinuousPanTiltVelocitySpace>space/cont-pantilt</DefaultContinuousPanTiltVelocitySpace>
+        <DefaultContinuousZoomVelocitySpace>space/cont-zoom</DefaultContinuousZoomVelocitySpace>
+        <DefaultPTZSpeed>
+            <PanTilt x="0.11" y="0.22" space="space/speed-pantilt"/>
+            <Zoom x="0.33" space="space/speed-zoom"/>
+        </DefaultPTZSpeed>
+        <DefaultPTZTimeout>PT4M5S</DefaultPTZTimeout>
+        <PanTiltLimits>
+            <Range>
+                <URI>space/pantilt-limit</URI>
+                <XRange><Min>-11</Min><Max>12</Max></XRange>
+                <YRange><Min>-13</Min><Max>14</Max></YRange>
+            </Range>
+        </PanTiltLimits>
+        <ZoomLimits>
+            <Range>
+                <URI>space/zoom-limit</URI>
+                <XRange><Min>15</Min><Max>16</Max></XRange>
+            </Range>
+        </ZoomLimits>
+    </PTZConfiguration>`
+
+// assertFullPTZConfiguration checks every field of the configuration described
+// by ptzConfigurationResponseBody.
+func assertFullPTZConfiguration(t *testing.T, config *PTZConfiguration) {
+	t.Helper()
+
+	for _, check := range []struct {
+		field string
+		got   string
+		want  string
+	}{
+		{"Token", config.Token, "cfg-42"},
+		{"Name", config.Name, "Main PTZ"},
+		{"NodeToken", config.NodeToken, "node-9"},
+		{"DefaultAbsolutePantTiltPositionSpace", config.DefaultAbsolutePantTiltPositionSpace, "space/abs-pantilt"},
+		{"DefaultAbsoluteZoomPositionSpace", config.DefaultAbsoluteZoomPositionSpace, "space/abs-zoom"},
+		{"DefaultRelativePanTiltTranslationSpace", config.DefaultRelativePanTiltTranslationSpace, "space/rel-pantilt"},
+		{"DefaultRelativeZoomTranslationSpace", config.DefaultRelativeZoomTranslationSpace, "space/rel-zoom"},
+		{"DefaultContinuousPanTiltVelocitySpace", config.DefaultContinuousPanTiltVelocitySpace, "space/cont-pantilt"},
+		{"DefaultContinuousZoomVelocitySpace", config.DefaultContinuousZoomVelocitySpace, "space/cont-zoom"},
+	} {
+		if check.got != check.want {
+			t.Errorf("%s = %q, want %q", check.field, check.got, check.want)
+		}
+	}
+
+	if config.UseCount != 7 {
+		t.Errorf("UseCount = %d, want 7", config.UseCount)
+	}
+
+	// An xs:duration, and the reason this whole set of fields needed a parser
+	// before it could be mapped at all.
+	if want := 4*time.Minute + 5*time.Second; config.DefaultPTZTimeout != want {
+		t.Errorf("DefaultPTZTimeout = %v, want %v", config.DefaultPTZTimeout, want)
+	}
+
+	assertPTZSpeed(t, config.DefaultPTZSpeed)
+	assertPanTiltLimits(t, config.PanTiltLimits)
+	assertZoomLimits(t, config.ZoomLimits)
+}
+
+func assertPTZSpeed(t *testing.T, speed *PTZSpeed) {
+	t.Helper()
+
+	if speed == nil {
+		t.Fatal("DefaultPTZSpeed = nil, want the speed from the response")
+	}
+	if speed.PanTilt == nil {
+		t.Fatal("DefaultPTZSpeed.PanTilt = nil")
+	}
+	if speed.PanTilt.X != 0.11 || speed.PanTilt.Y != 0.22 {
+		t.Errorf("DefaultPTZSpeed.PanTilt = (%v, %v), want (0.11, 0.22)", speed.PanTilt.X, speed.PanTilt.Y)
+	}
+	if speed.PanTilt.Space != "space/speed-pantilt" {
+		t.Errorf("DefaultPTZSpeed.PanTilt.Space = %q, want %q", speed.PanTilt.Space, "space/speed-pantilt")
+	}
+	if speed.Zoom == nil {
+		t.Fatal("DefaultPTZSpeed.Zoom = nil")
+	}
+	if speed.Zoom.X != 0.33 {
+		t.Errorf("DefaultPTZSpeed.Zoom.X = %v, want 0.33", speed.Zoom.X)
+	}
+	if speed.Zoom.Space != "space/speed-zoom" {
+		t.Errorf("DefaultPTZSpeed.Zoom.Space = %q, want %q", speed.Zoom.Space, "space/speed-zoom")
+	}
+}
+
+func assertPanTiltLimits(t *testing.T, limits *PanTiltLimits) {
+	t.Helper()
+
+	if limits == nil || limits.Range == nil {
+		t.Fatal("PanTiltLimits.Range = nil, want the limits from the response")
+	}
+	if limits.Range.URI != "space/pantilt-limit" {
+		t.Errorf("PanTiltLimits.Range.URI = %q, want %q", limits.Range.URI, "space/pantilt-limit")
+	}
+	if limits.Range.XRange == nil || limits.Range.XRange.Min != -11 || limits.Range.XRange.Max != 12 {
+		t.Errorf("PanTiltLimits.Range.XRange = %+v, want {-11 12}", limits.Range.XRange)
+	}
+	if limits.Range.YRange == nil || limits.Range.YRange.Min != -13 || limits.Range.YRange.Max != 14 {
+		t.Errorf("PanTiltLimits.Range.YRange = %+v, want {-13 14}", limits.Range.YRange)
+	}
+}
+
+func assertZoomLimits(t *testing.T, limits *ZoomLimits) {
+	t.Helper()
+
+	if limits == nil || limits.Range == nil {
+		t.Fatal("ZoomLimits.Range = nil, want the limits from the response")
+	}
+	if limits.Range.URI != "space/zoom-limit" {
+		t.Errorf("ZoomLimits.Range.URI = %q, want %q", limits.Range.URI, "space/zoom-limit")
+	}
+	if limits.Range.XRange == nil || limits.Range.XRange.Min != 15 || limits.Range.XRange.Max != 16 {
+		t.Errorf("ZoomLimits.Range.XRange = %+v, want {15 16}", limits.Range.XRange)
+	}
+}
+
+func TestGetConfigurationMapsEveryPTZConfigurationField(t *testing.T) {
+	body := `<GetConfigurationResponse>` + ptzConfigurationResponseBody + `</GetConfigurationResponse>`
+	client := newPTZTestClient(t, newSOAPTestServer(t, body))
+
+	config, err := client.GetConfiguration(context.Background(), "cfg-42")
+	if err != nil {
+		t.Fatalf("GetConfiguration() error = %v", err)
+	}
+
+	assertFullPTZConfiguration(t, config)
+}
+
+func TestGetConfigurationsMapsEveryPTZConfigurationField(t *testing.T) {
+	body := `<GetConfigurationsResponse>` + ptzConfigurationResponseBody + `</GetConfigurationsResponse>`
+	client := newPTZTestClient(t, newSOAPTestServer(t, body))
+
+	configs, err := client.GetConfigurations(context.Background())
+	if err != nil {
+		t.Fatalf("GetConfigurations() error = %v", err)
+	}
+	if len(configs) != 1 {
+		t.Fatalf("GetConfigurations() returned %d configurations, want 1", len(configs))
+	}
+
+	// The plural getter had its own copy of the truncated response struct, so
+	// it needs its own assertion rather than trusting the singular one.
+	assertFullPTZConfiguration(t, configs[0])
+}
+
+// TestGetConfigurationOptionalsAbsent keeps the optional sub-structures nil
+// rather than allocating zero-valued ones, so a caller can tell "the camera
+// did not report limits" from "the limits are zero".
+func TestGetConfigurationOptionalsAbsent(t *testing.T) {
+	body := `<GetConfigurationResponse>
+        <PTZConfiguration token="cfg-min">
+            <Name>Minimal</Name>
+            <UseCount>1</UseCount>
+            <NodeToken>node-1</NodeToken>
+        </PTZConfiguration>
+    </GetConfigurationResponse>`
+	client := newPTZTestClient(t, newSOAPTestServer(t, body))
+
+	config, err := client.GetConfiguration(context.Background(), "cfg-min")
+	if err != nil {
+		t.Fatalf("GetConfiguration() error = %v", err)
+	}
+
+	if config.DefaultPTZSpeed != nil {
+		t.Errorf("DefaultPTZSpeed = %+v, want nil when absent", config.DefaultPTZSpeed)
+	}
+	if config.PanTiltLimits != nil {
+		t.Errorf("PanTiltLimits = %+v, want nil when absent", config.PanTiltLimits)
+	}
+	if config.ZoomLimits != nil {
+		t.Errorf("ZoomLimits = %+v, want nil when absent", config.ZoomLimits)
+	}
+	if config.DefaultPTZTimeout != 0 {
+		t.Errorf("DefaultPTZTimeout = %v, want 0 when absent", config.DefaultPTZTimeout)
+	}
+
+	// The four fields that always worked must keep working.
+	if config.Token != "cfg-min" || config.NodeToken != "node-1" {
+		t.Errorf("Token/NodeToken = %q/%q, want cfg-min/node-1", config.Token, config.NodeToken)
+	}
+}

--- a/ptz_configuration_test.go
+++ b/ptz_configuration_test.go
@@ -6,9 +6,12 @@ import (
 	"time"
 )
 
-// Tests for #87: GetConfiguration and GetConfigurations returned a
-// PTZConfiguration with 10 of its 14 fields permanently zero, because the
-// response structs declared only the other four.
+// Tests for #87 and #89: PTZ responses that parsed fields off the wire and
+// then dropped them.
+//
+// #87: GetConfiguration and GetConfigurations returned a PTZConfiguration with
+// 10 of its 14 fields permanently zero, because the response structs declared
+// only the other four. #89: GetStatus declared UtcTime and never assigned it.
 //
 // Every value below is distinct. That is deliberate: a mapping test whose
 // fields share values cannot catch two of them being swapped, which is the
@@ -205,5 +208,51 @@ func TestGetConfigurationOptionalsAbsent(t *testing.T) {
 	// The four fields that always worked must keep working.
 	if config.Token != "cfg-min" || config.NodeToken != "node-1" {
 		t.Errorf("Token/NodeToken = %q/%q, want cfg-min/node-1", config.Token, config.NodeToken)
+	}
+}
+
+// TestGetStatusMapsUTCTime covers #89. The zero time was indistinguishable
+// from a camera that reported no timestamp, which is why no existing GetStatus
+// assertion could fail on it.
+func TestGetStatusMapsUTCTime(t *testing.T) {
+	tests := []struct {
+		name    string
+		element string
+		want    time.Time
+	}{
+		{
+			name:    "reported",
+			element: "<UtcTime>2026-09-06T14:30:45Z</UtcTime>",
+			want:    time.Date(2026, time.September, 6, 14, 30, 45, 0, time.UTC),
+		},
+		// Both remaining cases yield the zero time, deliberately: a status
+		// reading is still worth returning without a usable timestamp.
+		{name: "absent", element: ""},
+		{name: "malformed", element: "<UtcTime>yesterday</UtcTime>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `<GetStatusResponse>
+                <PTZStatus>
+                    <Position><Zoom x="0.5"/></Position>
+                    ` + tt.element + `
+                </PTZStatus>
+            </GetStatusResponse>`
+			client := newPTZTestClient(t, newSOAPTestServer(t, body))
+
+			status, err := client.GetStatus(context.Background(), testProfileToken)
+			if err != nil {
+				t.Fatalf("GetStatus() error = %v", err)
+			}
+			if !status.UTCTime.Equal(tt.want) {
+				t.Errorf("UTCTime = %v, want %v", status.UTCTime, tt.want)
+			}
+
+			// The rest of the status must survive either way.
+			if status.Position == nil || status.Position.Zoom == nil || status.Position.Zoom.X != 0.5 {
+				t.Errorf("Position = %+v, want Zoom.X 0.5", status.Position)
+			}
+		})
 	}
 }

--- a/session_timeout_test.go
+++ b/session_timeout_test.go
@@ -2,6 +2,7 @@ package onvif
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -26,12 +27,21 @@ const (
 // newRequestCapturingServer returns a server that records the body of each
 // request it receives before replying, for asserting what the client actually
 // put on the wire.
+//
+// io.ReadAll rather than a single Read into a ContentLength-sized buffer: one
+// Read is only obliged to return some of the bytes, so the short-read case
+// would silently truncate the captured body and turn a Contains assertion
+// into a flake.
 func newRequestCapturingServer(t *testing.T, captured *string) *httptest.Server {
 	t.Helper()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body := make([]byte, r.ContentLength)
-		_, _ = r.Body.Read(body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read captured request body: %v", err)
+
+			return
+		}
 		*captured = string(body)
 
 		w.Header().Set("Content-Type", "application/soap+xml")

--- a/session_timeout_test.go
+++ b/session_timeout_test.go
@@ -1,0 +1,356 @@
+package onvif
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Tests for #86: SessionTimeout was parsed off the wire and then dropped on
+// read, and never populated on write, on every Media method carrying it.
+//
+// Each read test asserts a value that could only have come from the response,
+// which is what the previous tests could not do - they asserted the other
+// fields and left a zero SessionTimeout looking like a camera that had not
+// reported one.
+
+const (
+	testSessionTimeoutXML = "PT90S"
+	testMetadataCfgToken  = "MetaCfg1"
+	testSessionTimeoutDur = 90 * time.Second
+)
+
+// newRequestCapturingServer returns a server that records the body of each
+// request it receives before replying, for asserting what the client actually
+// put on the wire.
+func newRequestCapturingServer(t *testing.T, captured *string) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		*captured = string(body)
+
+		w.Header().Set("Content-Type", "application/soap+xml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+    <soap:Body/>
+</soap:Envelope>`))
+	}))
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func TestGetVideoEncoderConfigurationMapsSessionTimeout(t *testing.T) {
+	body := `<GetVideoEncoderConfigurationResponse>
+        <Configuration token="VideoEnc1">
+            <Name>Encoder</Name>
+            <UseCount>1</UseCount>
+            <Encoding>H264</Encoding>
+            <Quality>5</Quality>
+            <SessionTimeout>` + testSessionTimeoutXML + `</SessionTimeout>
+        </Configuration>
+    </GetVideoEncoderConfigurationResponse>`
+	client := newMediaConfigClient(t, newSOAPTestServer(t, body).URL)
+
+	config, err := client.GetVideoEncoderConfiguration(context.Background(), testVideoEncToken)
+	if err != nil {
+		t.Fatalf("GetVideoEncoderConfiguration() error = %v", err)
+	}
+	if config.SessionTimeout != testSessionTimeoutDur {
+		t.Errorf("SessionTimeout = %v, want %v", config.SessionTimeout, testSessionTimeoutDur)
+	}
+}
+
+func TestGetAudioEncoderConfigurationMapsSessionTimeout(t *testing.T) {
+	body := `<GetAudioEncoderConfigurationResponse>
+        <Configuration token="AudioEnc1">
+            <Name>Encoder</Name>
+            <UseCount>1</UseCount>
+            <Encoding>AAC</Encoding>
+            <Bitrate>64</Bitrate>
+            <SampleRate>48000</SampleRate>
+            <SessionTimeout>` + testSessionTimeoutXML + `</SessionTimeout>
+        </Configuration>
+    </GetAudioEncoderConfigurationResponse>`
+	client := newMediaConfigClient(t, newSOAPTestServer(t, body).URL)
+
+	config, err := client.GetAudioEncoderConfiguration(context.Background(), testAudioEncToken)
+	if err != nil {
+		t.Fatalf("GetAudioEncoderConfiguration() error = %v", err)
+	}
+	if config.SessionTimeout != testSessionTimeoutDur {
+		t.Errorf("SessionTimeout = %v, want %v", config.SessionTimeout, testSessionTimeoutDur)
+	}
+}
+
+func TestGetMetadataConfigurationMapsSessionTimeout(t *testing.T) {
+	body := `<GetMetadataConfigurationResponse>
+        <Configuration token="MetaCfg1">
+            <Name>Metadata</Name>
+            <UseCount>1</UseCount>
+            <Analytics>true</Analytics>
+            <SessionTimeout>` + testSessionTimeoutXML + `</SessionTimeout>
+        </Configuration>
+    </GetMetadataConfigurationResponse>`
+	client := newMediaConfigClient(t, newSOAPTestServer(t, body).URL)
+
+	config, err := client.GetMetadataConfiguration(context.Background(), testMetadataCfgToken)
+	if err != nil {
+		t.Fatalf("GetMetadataConfiguration() error = %v", err)
+	}
+	if config.SessionTimeout != testSessionTimeoutDur {
+		t.Errorf("SessionTimeout = %v, want %v", config.SessionTimeout, testSessionTimeoutDur)
+	}
+}
+
+// TestListGettersMapSessionTimeout covers the plural and compatible-for-profile
+// variants, which each had their own copy of the same dropped mapping.
+func TestListGettersMapSessionTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		call func(*Client) (time.Duration, error)
+	}{
+		{
+			name: "GetVideoEncoderConfigurations",
+			body: `<GetVideoEncoderConfigurationsResponse>
+                <Configurations token="VideoEnc1">
+                    <Name>Encoder</Name><UseCount>1</UseCount><Encoding>H264</Encoding>
+                    <SessionTimeout>` + testSessionTimeoutXML + `</SessionTimeout>
+                </Configurations>
+            </GetVideoEncoderConfigurationsResponse>`,
+			call: func(c *Client) (time.Duration, error) {
+				configs, err := c.GetVideoEncoderConfigurations(context.Background())
+				if err != nil {
+					return 0, err
+				}
+
+				return configs[0].SessionTimeout, nil
+			},
+		},
+		{
+			name: "GetAudioEncoderConfigurations",
+			body: `<GetAudioEncoderConfigurationsResponse>
+                <Configurations token="AudioEnc1">
+                    <Name>Encoder</Name><UseCount>1</UseCount><Encoding>AAC</Encoding>
+                    <SessionTimeout>` + testSessionTimeoutXML + `</SessionTimeout>
+                </Configurations>
+            </GetAudioEncoderConfigurationsResponse>`,
+			call: func(c *Client) (time.Duration, error) {
+				configs, err := c.GetAudioEncoderConfigurations(context.Background())
+				if err != nil {
+					return 0, err
+				}
+
+				return configs[0].SessionTimeout, nil
+			},
+		},
+		{
+			name: "GetMetadataConfigurations",
+			body: `<GetMetadataConfigurationsResponse>
+                <Configurations token="MetaCfg1">
+                    <Name>Metadata</Name><UseCount>1</UseCount>
+                    <SessionTimeout>` + testSessionTimeoutXML + `</SessionTimeout>
+                </Configurations>
+            </GetMetadataConfigurationsResponse>`,
+			call: func(c *Client) (time.Duration, error) {
+				configs, err := c.GetMetadataConfigurations(context.Background())
+				if err != nil {
+					return 0, err
+				}
+
+				return configs[0].SessionTimeout, nil
+			},
+		},
+		{
+			name: "GetCompatibleVideoEncoderConfigurations",
+			body: `<GetCompatibleVideoEncoderConfigurationsResponse>
+                <Configurations token="VideoEnc1">
+                    <Name>Encoder</Name><UseCount>1</UseCount><Encoding>H264</Encoding>
+                    <SessionTimeout>` + testSessionTimeoutXML + `</SessionTimeout>
+                </Configurations>
+            </GetCompatibleVideoEncoderConfigurationsResponse>`,
+			call: func(c *Client) (time.Duration, error) {
+				configs, err := c.GetCompatibleVideoEncoderConfigurations(context.Background(), testProfileToken)
+				if err != nil {
+					return 0, err
+				}
+
+				return configs[0].SessionTimeout, nil
+			},
+		},
+		{
+			name: "GetCompatibleAudioEncoderConfigurations",
+			body: `<GetCompatibleAudioEncoderConfigurationsResponse>
+                <Configurations token="AudioEnc1">
+                    <Name>Encoder</Name><UseCount>1</UseCount><Encoding>AAC</Encoding>
+                    <SessionTimeout>` + testSessionTimeoutXML + `</SessionTimeout>
+                </Configurations>
+            </GetCompatibleAudioEncoderConfigurationsResponse>`,
+			call: func(c *Client) (time.Duration, error) {
+				configs, err := c.GetCompatibleAudioEncoderConfigurations(context.Background(), testProfileToken)
+				if err != nil {
+					return 0, err
+				}
+
+				return configs[0].SessionTimeout, nil
+			},
+		},
+		{
+			name: "GetCompatibleMetadataConfigurations",
+			body: `<GetCompatibleMetadataConfigurationsResponse>
+                <Configurations token="MetaCfg1">
+                    <Name>Metadata</Name><UseCount>1</UseCount>
+                    <SessionTimeout>` + testSessionTimeoutXML + `</SessionTimeout>
+                </Configurations>
+            </GetCompatibleMetadataConfigurationsResponse>`,
+			call: func(c *Client) (time.Duration, error) {
+				configs, err := c.GetCompatibleMetadataConfigurations(context.Background(), testProfileToken)
+				if err != nil {
+					return 0, err
+				}
+
+				return configs[0].SessionTimeout, nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newMediaConfigClient(t, newSOAPTestServer(t, tt.body).URL)
+
+			got, err := tt.call(client)
+			if err != nil {
+				t.Fatalf("%s() error = %v", tt.name, err)
+			}
+			if got != testSessionTimeoutDur {
+				t.Errorf("%s() SessionTimeout = %v, want %v", tt.name, got, testSessionTimeoutDur)
+			}
+		})
+	}
+}
+
+// TestSettersSendSessionTimeout is the write half of #86: the request structs
+// already carried the element, but nothing ever populated it, so a caller's
+// value never left the process.
+func TestSettersSendSessionTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(*Client) error
+	}{
+		{
+			name: "SetVideoEncoderConfiguration",
+			call: func(c *Client) error {
+				return c.SetVideoEncoderConfiguration(context.Background(), &VideoEncoderConfiguration{
+					Token:          testVideoEncToken,
+					Encoding:       "H264",
+					SessionTimeout: testSessionTimeoutDur,
+				}, false)
+			},
+		},
+		{
+			name: "SetAudioEncoderConfiguration",
+			call: func(c *Client) error {
+				return c.SetAudioEncoderConfiguration(context.Background(), &AudioEncoderConfiguration{
+					Token:          testAudioEncToken,
+					Encoding:       testEncodingAAC,
+					SessionTimeout: testSessionTimeoutDur,
+				}, false)
+			},
+		},
+		{
+			name: "SetMetadataConfiguration",
+			call: func(c *Client) error {
+				return c.SetMetadataConfiguration(context.Background(), &MetadataConfiguration{
+					Token:          testMetadataCfgToken,
+					SessionTimeout: testSessionTimeoutDur,
+				}, false)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sent string
+			client := newMediaConfigClient(t, newRequestCapturingServer(t, &sent).URL)
+
+			if err := tt.call(client); err != nil {
+				t.Fatalf("%s() error = %v", tt.name, err)
+			}
+
+			// formatDuration normalizes, so 90s goes out as "PT1M30S" rather
+			// than "PT90S". Deriving the expected text from the same formatter
+			// the client uses keeps this asserting that the value reached the
+			// wire, without also pinning a lexical choice #86 did not make.
+			want := "SessionTimeout>" + formatDuration(testSessionTimeoutDur)
+			if !strings.Contains(sent, want) {
+				t.Errorf("%s() did not send %q\nrequest:\n%s", tt.name, want, sent)
+			}
+		})
+	}
+}
+
+// TestSettersOmitZeroSessionTimeout keeps the element off the wire when the
+// caller did not ask for one, rather than sending "PT0S" and overwriting a
+// camera's own default.
+func TestSettersOmitZeroSessionTimeout(t *testing.T) {
+	var sent string
+	client := newMediaConfigClient(t, newRequestCapturingServer(t, &sent).URL)
+
+	err := client.SetAudioEncoderConfiguration(context.Background(), &AudioEncoderConfiguration{
+		Token:    testAudioEncToken,
+		Encoding: testEncodingAAC,
+	}, false)
+	if err != nil {
+		t.Fatalf("SetAudioEncoderConfiguration() error = %v", err)
+	}
+	if strings.Contains(sent, "SessionTimeout") {
+		t.Errorf("a zero SessionTimeout was sent anyway\nrequest:\n%s", sent)
+	}
+}
+
+// TestSessionTimeoutAbsentOrMalformed documents the two cases that legitimately
+// yield zero, so that a future reader does not mistake them for the bug #86
+// fixed.
+func TestSessionTimeoutAbsentOrMalformed(t *testing.T) {
+	tests := []struct {
+		name    string
+		element string
+	}{
+		{name: "absent", element: ""},
+		{name: "malformed", element: "<SessionTimeout>not-a-duration</SessionTimeout>"},
+		{name: "months are unrepresentable", element: "<SessionTimeout>P1M</SessionTimeout>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `<GetAudioEncoderConfigurationResponse>
+                <Configuration token="AudioEnc1">
+                    <Name>Encoder</Name><UseCount>1</UseCount><Encoding>AAC</Encoding>
+                    ` + tt.element + `
+                </Configuration>
+            </GetAudioEncoderConfigurationResponse>`
+			client := newMediaConfigClient(t, newSOAPTestServer(t, body).URL)
+
+			// A malformed timeout must not fail the call - every other field
+			// in the configuration is still usable.
+			config, err := client.GetAudioEncoderConfiguration(context.Background(), testAudioEncToken)
+			if err != nil {
+				t.Fatalf("GetAudioEncoderConfiguration() error = %v", err)
+			}
+			if config.SessionTimeout != 0 {
+				t.Errorf("SessionTimeout = %v, want 0", config.SessionTimeout)
+			}
+			if config.Encoding != testEncodingAAC {
+				t.Errorf("Encoding = %q, want %q - the rest of the response must survive",
+					config.Encoding, testEncodingAAC)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #86. Closes #87.

Four public config types declared `time.Duration` fields that no code path ever assigned or read. `grep` for them across the client returned only their declarations:

```
$ grep -rn 'SessionTimeout' --include='*.go' . | grep -vE 'xml:"'
types.go:164:   SessionTimeout time.Duration
types.go:176:   SessionTimeout time.Duration
types.go:206:   SessionTimeout time.Duration
server/media.go:215:  SessionTimeout: sessionTimeout,   # the simulator, unrelated
server/media.go:245:  SessionTimeout: sessionTimeout,

$ grep -rn 'DefaultPTZTimeout' --include='*.go' .
types.go:192:   DefaultPTZTimeout                      time.Duration
```

Every caller saw a zero regardless of what the camera reported, and every caller who set one had it discarded before the request went out. Neither direction produced an error.

## Root cause

These are `xs:duration` on the wire and `time.Duration` in Go, and the client had no parser — `formatDuration` is emit-only. Whoever wrote the mappings had nothing to convert the parsed string with and left the assignment out, in **nine read paths and three write paths**.

## What changed

**`duration.go`** — `parseXSDuration`, deliberately more permissive than `server/event.go`'s `isoDurationPattern`. That one covers just the `PT<n>M<n>S` subset this library itself emits, which is correct for the server: it parses values an ONVIF *client* produced, and #62 scoped it to what could be tested. Here the producer is camera firmware, free to use any lexical form the schema allows, so `PT0H1M0S` and `P1D` have to work too. The server's parser is left alone — broadening it as a side effect of a client bug fix, and editing its `P1D`-must-error test to suit, would be the wrong move.

Years and months are **refused** rather than approximated: neither has a fixed length, and every element this is used for is a timeout, where they do not occur.

**`media.go`** — `SessionTimeout` mapped on 9 read paths, populated on 3 write paths. Zero values stay off the wire so a `Set*` cannot overwrite a camera's own default with `PT0S`.

**`ptz.go`** — #87 additionally needed the other nine `PTZConfiguration` fields, which were absent from the response structs entirely rather than parsed and dropped. The default position/velocity spaces are how a caller learns which space an `AbsoluteMove` should use, and `PanTiltLimits`/`ZoomLimits` are the only way to discover a camera's valid range before sending a request it would reject. `GetConfiguration` and `GetConfigurations` each had their own truncated copy of that struct, so both now share `ptzConfigurationXML`.

## Response-mapping tradeoff

Read paths use `parseXSDurationOrZero`, which swallows a parse failure. A camera reporting a malformed timeout should not fail an entire `GetConfiguration` call when every other field is still good, and `Client` has no logger to report the discrepancy through. The cost is that a malformed value is indistinguishable from an absent one — `TestSessionTimeoutAbsentOrMalformed` pins both cases so this reads as a decision rather than an oversight.

## Verification

- `gofmt`, `go vet ./...`, `go build ./...` clean
- `go test -count=1 -race ./...` — all packages pass
- `golangci-lint run --timeout=5m --max-issues-per-linter=0 --max-same-issues=0 ./...` — **0 issues**
- Every mapping assertion uses a **distinct sentinel per field**, so a swapped pair fails rather than passing on coincidentally equal values.

**Mutation-tested**, because a mapping test that passes whether or not the mapping is correct is worthless:

| Mutation | Result |
|---|---|
| swap `DefaultAbsoluteZoomPositionSpace` ↔ `DefaultRelativePanTiltTranslationSpace` | both PTZ mapping tests fail |
| delete one `SessionTimeout` assignment | `TestGetAudioEncoderConfigurationMapsSessionTimeout` fails |

Restored exactly afterwards; suite green.

## How this was found

Nothing in the suite verified response field mappings at all — the gap the client coverage issues (#10, #11, #12) exist to close. This surfaced while writing those tests, which is the argument for that work.

This PR is the base of a stack: the coverage PRs for #10/#11/#12 follow.
